### PR TITLE
[intrinsics] Use the `__ARM_NEON` macro for the Advanced SIMD support

### DIFF
--- a/neon_intrinsics/advsimd.rst
+++ b/neon_intrinsics/advsimd.rst
@@ -155,7 +155,7 @@ List of Intrinsics
 Basic intrinsics
 ================
 
-The intrinsics in this section are guarded by the macro ``__ARM_FEATURE_SVE``.
+The intrinsics in this section are guarded by the macro ``__ARM_NEON``.
 
 Vector arithmetic
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #15: Advanced SIMD support is available if the `__ARM_NEON` macro is predefined, <https://developer.arm.com/documentation/101028/0012/13--Advanced-SIMD--Neon--intrinsics>.