### PR TITLE
[intrinsics] Use the `__ARM_NEON` macro for the Advanced SIMD support.

### DIFF
--- a/neon_intrinsics/advsimd.rst
+++ b/neon_intrinsics/advsimd.rst
@@ -147,8 +147,8 @@ Document history
 +------------+-------------------------+-------------------------+
 
 
-Changes between next release  and 2021Q2
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Changes between next release and 2021Q2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Fixed the guard macro for the base intrinsics.
 
 List of Intrinsics
@@ -27492,4 +27492,3 @@ Vector multiply-accumulate by scalar
 |         bfloat16x8_t b,              |     0 <= lane <= 7     |                                    |                     |                           |
 |         const int lane)              |                        |                                    |                     |                           |
 +--------------------------------------+------------------------+------------------------------------+---------------------+---------------------------+
-

--- a/neon_intrinsics/advsimd.rst
+++ b/neon_intrinsics/advsimd.rst
@@ -1,6 +1,6 @@
 .. |copyright-date| replace:: 2014-2021
-.. |release| replace:: 2021Q2
-.. |date-of-issue| replace:: 02 July 2021
+.. |release| replace:: development version based on 2021Q2
+.. |date-of-issue| replace:: TBD
 .. |footer| replace:: Copyright © |copyright-date|, Arm Limited and its
                       affiliates. All rights reserved.
 
@@ -141,11 +141,15 @@ Document history
 +------------+-------------------------+-------------------------+
 |F           |30 May 2020              |Version ACLE Q2 2020     |
 +------------+-------------------------+-------------------------+
-|G           |30 October 2020          |Version ACLE Q2 2020     |
+|G           |30 October 2020          |Version ACLE Q3 2020     |
 +------------+-------------------------+-------------------------+
-|H           | |date-of-issue|         | |release|               |
+|H           |02 July 2021             |              2021Q2     |
 +------------+-------------------------+-------------------------+
 
+
+Changes between next release  and 2021Q2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fixed the guard macro for the base intrinsics.
 
 List of Intrinsics
 ##################
@@ -155,7 +159,7 @@ List of Intrinsics
 Basic intrinsics
 ================
 
-The intrinsics in this section are guarded by the macro ``__ARM_FEATURE_SVE``.
+The intrinsics in this section are guarded by the macro ``__ARM_NEON``.
 
 Vector arithmetic
 ~~~~~~~~~~~~~~~~~

--- a/neon_intrinsics/advsimd.template.rst
+++ b/neon_intrinsics/advsimd.template.rst
@@ -1,6 +1,6 @@
 .. |copyright-date| replace:: 2014-2021
-.. |release| replace:: 2021Q2
-.. |date-of-issue| replace:: 02 July 2021
+.. |release| replace:: development version based on 2021Q2
+.. |date-of-issue| replace:: TBD
 .. |footer| replace:: Copyright © |copyright-date|, Arm Limited and its
                       affiliates. All rights reserved.
 
@@ -141,11 +141,15 @@ Document history
 +------------+-------------------------+-------------------------+
 |F           |30 May 2020              |Version ACLE Q2 2020     |
 +------------+-------------------------+-------------------------+
-|G           |30 October 2020          |Version ACLE Q2 2020     |
+|G           |30 October 2020          |Version ACLE Q3 2020     |
 +------------+-------------------------+-------------------------+
-|H           | |date-of-issue|         | |release|               |
+|H           |02 July 2021             |              2021Q2     |
 +------------+-------------------------+-------------------------+
 
+
+Changes between next release  and 2021Q2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fixed the guard macro for the base intrinsics.
 
 List of Intrinsics
 ##################

--- a/neon_intrinsics/advsimd.template.rst
+++ b/neon_intrinsics/advsimd.template.rst
@@ -147,12 +147,11 @@ Document history
 +------------+-------------------------+-------------------------+
 
 
-Changes between next release  and 2021Q2
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Changes between next release and 2021Q2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Fixed the guard macro for the base intrinsics.
 
 List of Intrinsics
 ##################
 
 {intrinsic_table}
-

--- a/tools/intrinsic_db/advsimd.csv
+++ b/tools/intrinsic_db/advsimd.csv
@@ -13,7 +13,7 @@
 <COMMENT>	See the License for the specific language governing permissions and
 <COMMENT>	limitations under the License.
 <HEADER>	Intrinsic	Argument preparation	AArch64 Instruction	Result	Supported architectures
-<SECTION>	Basic intrinsics	The intrinsics in this section are guarded by the macro ``__ARM_FEATURE_SVE``.
+<SECTION>	Basic intrinsics	The intrinsics in this section are guarded by the macro ``__ARM_NEON``.
 int8x8_t vadd_s8(int8x8_t a, int8x8_t b)	a -> Vn.8B;b -> Vm.8B	ADD Vd.8B,Vn.8B,Vm.8B	Vd.8B -> result	v7/A32/A64
 int8x16_t vaddq_s8(int8x16_t a, int8x16_t b)	a -> Vn.16B;b -> Vm.16B	ADD Vd.16B,Vn.16B,Vm.16B	Vd.16B -> result	v7/A32/A64
 int16x4_t vadd_s16(int16x4_t a, int16x4_t b)	a -> Vn.4H;b -> Vm.4H	ADD Vd.4H,Vn.4H,Vm.4H	Vd.4H -> result	v7/A32/A64


### PR DESCRIPTION
Fixes #15: Advanced SIMD support is available if the __ARM_NEON macro is predefined, https://developer.arm.com/documentation/101028/0012/13--Advanced-SIMD--Neon--intrinsics.