### PR TITLE
[github.io] Add markdown-link-check as part of CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,9 @@ jobs:
       with:
         name: pdfs
         path: pdfs
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
This CI worflow was originally written by @ValeriaDaneva in #43 