### PR TITLE
[ACLE] Add Pointer Authentication and Branch Target Identification extension target feature macros.

### DIFF
--- a/main/acle.rst
+++ b/main/acle.rst
@@ -270,6 +270,8 @@ Changes between ACLE Q2 2021 and ACLE Q3 2021
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Fixed FP16 format description at ssec-fp16-type_.
 * Fixed the description of at ssec-NEON-intrinsics-concepts_.
+* Introduce ``__ARM_FEATURE_PAUTH`` and ``__ARM_FEATURE_BTI`` in sections
+  ssec-PAC_ and ssec-BTI_ respectively.
 
 References
 ----------
@@ -1795,6 +1797,9 @@ Identification extension is used to protect branch destinations by default.
 The protection applied to any particular function may be overriden by
 mechanisms such as function attributes.
 
+``__ARM_FEATURE_BTI`` is defined to 1 if Branch Target Identification
+extension is available on the target. It is undefined otherwise.
+
 .. _ssec-PAC:
 
 Pointer Authentication
@@ -1820,6 +1825,9 @@ extension is used to protect function entry points, including leaf functions,
 using the A key for signing.
 The protection applied to any particular function may be overriden by
 mechanisms such as function attributes.
+
+``__ARM_FEATURE_PAUTH`` is defined to 1 if Pointer Authentication extension
+is available on the target. It is undefined otherwise.
 
 .. _ssec-MatMul:
 

--- a/main/design_documents/pacbti-m-tfm.rst
+++ b/main/design_documents/pacbti-m-tfm.rst
@@ -1,0 +1,67 @@
+
+Pointer Authentication(PAC) and Branch Target Identification (BTI) Target Feature Macros.
+=========================================================================================
+
+This documents presents the rationale behind introducing the target feature
+that identify PAC and BTI extensions. The macros are:
+
+``__ARM_FEATURE_PAUTH`` is defined to 1 if Pointer Authentication extension
+is available on the target. It is undefined otherwise.
+
+``__ARM_FEATURE_BTI`` is defined to 1 if Branch Target Identification
+extension is available on the target. It is undefined otherwise.
+
+How it differs from the other two macros introduced for PAC and BTI
+===================================================================
+
+Defining ``__ARM_FEATURE_PAUTH`` to 1 means that the target supports
+instructions like ``PAC``, ``AUT``, ``AUTG`` whereas
+``__ARM_FEATURE_PAC_DEFAULT`` means that the compiler has been instructed to
+generate the prologue and epilogue sequences that sign and authenticate return
+address. ``__ARM_FEATURE_PAUTH`` indicates the compiler has been invoked with
+the extension enabled, for example ``-march=armv8.1-m.main+pacbti``, whereas
+``__ARM_FEATURE_PAC_DEFAULT`` indicates the compiler has been invoked with
+``-mbranch-protection=pac-ret`` which is a code-generation option.
+
+The reason is similar for BTI.
+
+Why it is required to have target feature extension macros
+===========================================================
+
+There are scenarios in application code where the programmer has to choose
+between using instructions that work on legacy implementations and ones that
+don't. For example, on Armv8.1-M Mainline, ``PAC`` is backward compatible with
+legacy implementations of the architecture, where the optional ``PACBTI``
+extension is not implemented, while ``PACG`` is only available when the extension
+is implemented. This target feature macro can be used to determine which
+instructions to use according to what's available on the target. If an
+application is built to run on legacy and be backward compatible, ``PAC`` can be
+used. Contrarily, ``PACG`` can be used only when ``PACBTI`` target extension is
+implemented.
+
+Example:
+--------
+
+::
+
+  void
+  foo ()
+  {
+  #if __ARM_FEATURE_PAUTH
+    asm ("PACG R0, R1, R2");
+  #else
+    asm ("PAC R12, LR, SP");
+  #endif
+
+    ...
+
+  #if __ARM_FEATURE_PAUTH
+    asm ("AUTG R0, R1, R2");
+  #else
+    asm ("AUT R12, LR, SP");
+  #endif
+  }
+
+A real-world use-case of these macros is in the stack-unwinding runtime for
+exceptions where the runtime unwinding is potentially better with ``AUTG``
+rather than using ``AUT`` which forces register pressure.


### PR DESCRIPTION
The following change introduces feature test macros to test the presence of Pointer Authentication and Branch Target Identification extensions on the target.