### PR TITLE
[community] Add issue and pull request templates. (#70)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+---
+name: Bug report
+about: Technical issues, document format problems, bugs in scripts, and so on.
+title: "[BUG]"
+labels: bug
+assignees: fpetrogalli
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is. Please add
+references to the documents where the bug is.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem. This is
+useful for layout problems in the PDF or HTML pages.
+
+**Our commitment**
+
+We will work to solve the bug report in time for the upcoming
+release. However, we would like to encourage you to submit the fix
+yourself, if possible. If you intend to do so and this is your first
+contribution, we recommend reading our [contribution
+guidelines](../../CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,17 @@
+<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+---
+name: Proposing an extension
+about: Create new intrinsics, macros, and so on
+title: "[proposal]"
+
+---
+
+**Thank you for submitting a proposal!**
+
+We are looking forward to evaluate your proposal, and if possible to
+make it part of the Arm C Language Extension (ACLE) specifications.
+
+We would like to encourage you reading through the [contribution
+guidelines](../../CONTRIBUTING.md), in particular the section on [submitting
+a proposal](../../CONTRIBUTING.md#proposals-for-new-content).

--- a/.github/PULL_REQUEST_TEMPLATE/fixing-a-bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fixing-a-bug.md
@@ -1,0 +1,35 @@
+<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+---
+name: Fixing an issue.
+about: Technical issues, document format problems, bugs in scripts, and so on.
+title: "[bugfix]"
+label: bugfix
+
+---
+
+**Thank you for submitting a fix to the specifications.**
+
+Please make sure to go through the following checklist:
+
+* [ ] If an issue reporting the bug exists, I have mentioned it in the
+      PR (do not bother creating the issue if all you want to do is
+      fixing the bug yourself).
+* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
+      of any file I have edited. Format is `SPDX-FileCopyrightText:
+      Copyright {year} {entity or name} <{contact informations}>`
+      (Please update existing copyright lines if applicable. You can
+      specify year ranges with hyphen , as in `2017-2019`, and use
+      commas to separate gaps, as in `2018-2020, 2022`).
+* [ ] I have udated the `Copyright` section of the sources of the
+      specification I have edited (this will show up in the text
+      rendered in the PDF and other output format supported, the
+      format is the same described in the previous item).
+* [ ] I have run the CI scripts (if applicable, as they might be
+      tricky to set up on non-*nix machines. The sequence can be found
+      in the [contribution
+      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
+      worry if you cannot run these scripts on your machine, your
+      patch will be automatically checked in the Actions of the pull
+      request).
+* [ ] The pull request is done against the branch `next-release`.

--- a/.github/PULL_REQUEST_TEMPLATE/proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/proposal.md
@@ -1,0 +1,40 @@
+<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+---
+name: Proposing an extension
+about: Create new intrinsics, macros, and so on.
+title: "[proposal]"
+label: proposal
+
+---
+
+**Thank you for submitting a proposal!**
+
+We are looking forward to evaluate your proposal, and if possible to
+make it part of the Arm C Language Extension (ACLE) specifications.
+
+We would like to encourage you reading through the [contribution
+guidelines](../../CONTRIBUTING.md), in particular the section on [submitting
+a proposal](../../CONTRIBUTING.md#proposals-for-new-content).
+
+As for any pull request, please make sure to go through the following
+checklist (mark with ``X`` those which apply):
+
+* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
+      of any file I have edited. Format is `SPDX-FileCopyrightText:
+      Copyright {year} {entity or name} <{contact informations}>`
+      (Please update existing copyright lines if applicable. You can
+      specify year ranges with hyphen , as in `2017-2019`, and use
+      commas to separate gaps, as in `2018-2020, 2022`).
+* [ ] I have udated the `Copyright` section of the sources of the
+      specification I have edited (this will show up in the text
+      rendered in the PDF and other output format supported). The
+      format is the same described in the previous item.
+* [ ] I have run the CI scripts (if applicable, as they might be
+      tricky to set up on non-*nix machines). The sequence can be
+      found in the [contribution
+      guidelines](../../CONTRIBUTING.md#continuous-integration). Don't
+      worry if you cannot run these scripts on your machine, your
+      patch will be automatically checked in the Actions of the pull
+      request.
+* [ ] The pull request is done against the branch `next-release`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,22 @@ The scripts run in the CI configuration of the project. PDFs are
 generated automatically in response to a pull request. You can
 download the PDFs in the `Actions` tab of any pull request.
 
+# Continuous integration
+
+The full sequence executed by the continuous integrations bot is as
+follows:
+
+```
+./tools/generate-intrinsics-specs.sh
+./tools/check-rst-syntax.sh
+./tools/generate-pdfs.sh
+```
+
+An additional step uses
+[``markdown-link-check```](https://github.com/tcort/markdown-link-check)
+to check that all the links in the markdown files are resolving
+correcly.
+
 # Branches and pull requests.
 
 The branch `main` is the release branch, which contains the code used


### PR DESCRIPTION
Cherry picking #70 to make it available in GitHub's PRs and ISSUEs interfaces.