### PR TITLE
[community] Fix trademark notice.

### DIFF
--- a/main/TRADEMARK_NOTICE.md
+++ b/main/TRADEMARK_NOTICE.md
@@ -8,7 +8,7 @@ The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/main/acle.rst
+++ b/main/acle.rst
@@ -137,7 +137,7 @@ The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/morello/TRADEMARK_NOTICE.md
+++ b/morello/TRADEMARK_NOTICE.md
@@ -8,7 +8,7 @@ The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/morello/morello.rst
+++ b/morello/morello.rst
@@ -129,7 +129,7 @@ The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/mve_intrinsics/TRADEMARK_NOTICE.md
+++ b/mve_intrinsics/TRADEMARK_NOTICE.md
@@ -8,7 +8,7 @@ The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/mve_intrinsics/mve.rst
+++ b/mve_intrinsics/mve.rst
@@ -117,7 +117,7 @@ The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/mve_intrinsics/mve.template.rst
+++ b/mve_intrinsics/mve.template.rst
@@ -117,7 +117,7 @@ The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/neon_intrinsics/TRADEMARK_NOTICE.md
+++ b/neon_intrinsics/TRADEMARK_NOTICE.md
@@ -8,7 +8,7 @@ The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/neon_intrinsics/advsimd.rst
+++ b/neon_intrinsics/advsimd.rst
@@ -118,7 +118,7 @@ The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.

--- a/neon_intrinsics/advsimd.template.rst
+++ b/neon_intrinsics/advsimd.template.rst
@@ -118,7 +118,7 @@ The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
 license ("CC-BY-SA-4.0”), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
-trademarks of Arm Limited and/or its affiliates (or its subsidiaries) in the US and/or
+trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit
 https://www.arm.com/company/policies/trademarks for more information
 about Arm’s trademarks.


### PR DESCRIPTION
A change in the trademark notice was erroneously introduced in
https://github.com/ARM-software/acle/pull/69.

This patch restore the original text of the trademark notice in all
places where it is used.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have udated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] The pull request is done against the branch `next-release`.
