### PR TITLE
[2021Q4] Set release numbers for 2021Q4

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -375,15 +375,15 @@ low-level library in C rather than assembler.
 
 ## Scalable Vector Extensions (SVE)
 
-ACLE support for SVE is defined in the Arm C Language Extensions for SVE
-document [[SVE-ACLE]](#SVE-ACLE) available on the Arm Developer Website.
+ACLE support for SVE is defined in the *Arm C Language Extensions for
+SVE* document [SVE-ACLE](#SVE-ACLE).
 
 
 ## Cortex-M Security Extension (CMSE)
 
 ACLE support for the Cortex-M Security Extension (CMSE) is defined in
 *Arm®v8-M Security Extensions: Requirements on Development Tools*
-document [CMSE-ACLE](#CMSE-ACLE) available on the Arm Developer Website.
+document [CMSE-ACLE](#CMSE-ACLE).
 
 # Introduction
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -1582,13 +1582,16 @@ Intrinsics for using these instructions are specified in
 
 ## memcpy family of memory operations standarization instructions - MOPS
 
-`__ARM_FEATURE_MOPS` is defined to 1 if the `CPYF*`, `CPY*`, `SET*` and `SETG*`
-instructions introduced in the Armv8.8-A and Armv9.3-A architecture updates for
-standardization of the memcpy, memset, and memmove family of memory operations
-are supported.
-This macro may only ever be defined in the AArch64 execution state.
-Intrinsics for using these instructions are specified in
-[ssec-MOPS-intrinsics](#memcpy-family-of-operations-intrinsics---mops)
+If the `CPYF*`, `CPY*`, `SET*` and `SETG*` instructions are supported,
+`__ARM_FEATURE_MOPS` is defined to 1. These instructions were
+introduced in the Armv8.8-A and Armv9.3-A architecture updates for
+standardization of memorycpy, memset, and memmove family of memory
+operations (MOPS).
+
+The `__ARM_FEATURE_MOPS` macro can only be implemented in the AArch64
+execution state. Intrinsics for the use of these instructions are
+specified in [memcpy family of operations intrinsics -
+MOPS](#memcpy-family-of-operations-intrinsics---mops)
 
 ## Mapping of object build attributes to predefines
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -179,32 +179,41 @@ Armv8.3-A [[ARMARMv83]](#ARMARMv83). Support is added for the Complex addition a
 Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrinsics.
 
 #### Changes between ACLE Q2 2021 and ACLE Q3 2021
-* Fixed FP16 format description at [ssec-fp16-type](#half-precision-floating-point).
-* Fixed the description of `vmul_lane_u16` at 
-  [ssec-NEON-intrinsics-concepts](#neon-intrinsics-concepts).
+* Fixed FP16 format description at [Half-precision
+  floating-point](#half-precision-floating-point).
+* Fixed the description of `vmul_lane_u16` at
+  [Concepts](#neon-intrinsics-concepts).
 
 #### Changes between ACLE Q3 2021 and ACLE Q4 2021
 
-* Update copyright statement in section [Copyright](#copyright).
-* Introduce `__ARM_FEATURE_PAUTH` and `__ARM_FEATURE_BTI` in
-  sections [ssec-PAC](#pointer-authentication) and [ssec-BTI](#branch-target-identification) respectively.
+* Updated copyright statement in section [Copyright](#copyright).
+* Introduced `__ARM_FEATURE_PAUTH` and `__ARM_FEATURE_BTI` in sections
+  [Pointer Authentication](#pointer-authentication) and [Branch Target
+  Identification](#branch-target-identification) respectively.
 * Fix the changelog of 2021Q3, as is was missing the mentioning of the
   intrinsic `vmul_lane_u16` in the second item.
-* Fixed item lists rendering in [sec-MVE-intrinsics](#m-profile-vector-extension-mve-intrinsics).
+* Fixed item lists rendering in [M-profile Vector
+  Extension](#m-profile-vector-extension-mve-intrinsics).
 * Fixed superfluous and broken backticks in code examples throughout.
 * Added reference to the *Cortex-M Security Extension (CMSE)*
-  specifications in
-  [sec-CMSE-intrinsics](#cortex-m-security-extension-cmse).
-* Added specification for [sec-NEON-SVE-Bridge](#neon-sve-bridge) 
-  and [sec-NEON-SVE-Bridge-macros](#neon-sve-bridge-macros).
-* Added feature detection macro for the memcpy family of memory operations
-  (MOPS) at [ssec-MOPS](#memcpy-family-of-memory-operations-standarization-instructions---mops)
+  specifications in [Cortex-M Security Extension
+  (CMSE)](#cortex-m-security-extension-cmse).
+* Added specification for [NEON-SVE Bridge](#neon-sve-bridge) and
+  [NEON-SVE Bridge macros](#neon-sve-bridge-macros).
+* Added feature detection macro for the memcpy family of memory
+  operations (MOPS) at [memcpy family of memory operations
+  standarization instructions -
+  MOPS](#memcpy-family-of-memory-operations-standarization-instructions---mops)
 * Added intrinsic for the memcpy family of memory operations (MOPS) at
-  [ssec-MOPS-intrinsics](#memcpy-family-of-operations-intrinsics---mops)
+  [memcpy family of operations intrinsics -
+  MOPS](#memcpy-family-of-operations-intrinsics---mops)
 * Converted document sources from reStructuredText (`.rst`) to
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the
   standard layout used in Arm specifications.
+* Updated the section links in [Changes between ACLE Q2 2021 and ACLE
+  Q3 2021](#changes-between-acle-q2-2021-and-acle-q3-2021) by using
+  the actual section title.
 
 ### References
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -1,7 +1,7 @@
 ---
 title: Arm C Language Extensions
-version: Development version based on 2021Q3
-date-of-issue: TBD
+version: 2021Q4
+date-of-issue: 11 January 2021
 # LaTeX specific variables
 copyright-text: Copyright 2011-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
 # Jekyll specific variables
@@ -136,6 +136,7 @@ Copyright 2011-2022 Arm Limited and/or its affiliates <open-source-office@arm.co
 | ACLE Q3 2020 | 31/10/20          | Arm    | Version ACLE Q3 2020.                                                                                                |
 | 2021Q2       | 02 July 2021      | Arm    | Version ACLE Q2 2021. Open source version. NFCI.                                                                     |
 | 2021Q3       | 30 September 2021 | Arm    | Minor re-wording. NFCI.                                                                                              |
+| 2021Q4       | 11 January 2022   | Arm    | See [Changes between ACLE Q3 2021 and ACLE Q4 2021](#changes-between-acle-q3-2021-and-acle-q4-2021)                  |
 
 #### Changes between ACLE Q2 2020 and ACLE Q3 2020
 
@@ -182,7 +183,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Fixed the description of `vmul_lane_u16` at 
   [ssec-NEON-intrinsics-concepts](#neon-intrinsics-concepts).
 
-#### Changes for next release
+#### Changes between ACLE Q3 2021 and ACLE Q4 2021
 
 * Update copyright statement in section [Copyright](#copyright).
 * Introduce `__ARM_FEATURE_PAUTH` and `__ARM_FEATURE_BTI` in

--- a/main/acle.md
+++ b/main/acle.md
@@ -190,8 +190,8 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Introduced `__ARM_FEATURE_PAUTH` and `__ARM_FEATURE_BTI` in sections
   [Pointer Authentication](#pointer-authentication) and [Branch Target
   Identification](#branch-target-identification) respectively.
-* Fix the changelog of 2021Q3, as is was missing the mentioning of the
-  intrinsic `vmul_lane_u16` in the second item.
+* Fixed the changelog of 2021Q3, as is was missing the mentioning of
+  the intrinsic `vmul_lane_u16` in the second item.
 * Fixed item lists rendering in [M-profile Vector
   Extension](#m-profile-vector-extension-mve-intrinsics).
 * Fixed superfluous and broken backticks in code examples throughout.

--- a/morello/morello.md
+++ b/morello/morello.md
@@ -158,8 +158,10 @@ All content in this document is at the **Alpha** quality level.
 
 ### Changes for 02alpha
 
-* Update the copyright statement in section [Copyright](#copyright).
-* Add a reference to the [CHERI-HYBRID](https://github.com/CTSRD-CHERI/cheri-hybrid-c-guide) *CHERI Hybrid C/C++ Programming Guide* in section [Scope](#scope).
+* Updated the copyright statement in section [Copyright](#copyright).
+* Added a reference to the
+  [CHERI-HYBRID](https://github.com/CTSRD-CHERI/cheri-hybrid-c-guide)
+  *CHERI Hybrid C/C++ Programming Guide* in section [Scope](#scope).
 * Converted document sources from reStructuredText (`.rst`) to
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the

--- a/morello/morello.md
+++ b/morello/morello.md
@@ -200,7 +200,7 @@ This document refers to, or is referred to by, the following documents.
    When a capability is sealed it cannot be modified or dereferenced,
    but it can be used to implement opaque pointer types.
 
-## Scope
+# Scope
 
 The Morello Supplement to the Arm C Language Extensions highlights the
 language features added on top of the CHERI programming language to
@@ -210,16 +210,16 @@ further exploit the Morello architecture. We recommend reading the
 [CHERI-HYBRID](https://github.com/CTSRD-CHERI/cheri-hybrid-c-guide)
 *CHERI Hybrid C/C++ Programming Guide* as preliminary material.
 
-## Predefined macros
+# Predefined macros
 
 ACLE introduces several predefined macros that define how the C/C++
 implementation uses the Morello architecture.
 
-### `__ARM_FEATURE_C64`
+## `__ARM_FEATURE_C64`
 
 This macro indicates that the code is being compiled for the C64 ISA.
 
-### Capability Permissions
+## Capability Permissions
 
 The following macros indicate capability permissions:
 
@@ -236,17 +236,17 @@ Those can be used to form a bitmask that is acceptable for
 corresponds to the permission bit as it appears in the architecture
 documentation.
 
-### Deviation from CHERI
+## Deviation from CHERI
 
 The macro `__CHERI_CAP_PERMISSION_PERMIT_CCALL__` is not available on
 the Morello architecture.
 
-## Builtin functions
+# Builtin functions
 
 ACLE standardizes builtin functions to access the Morello architecture.
 These are the following:
 
-### Check subset and conditionally unseal or return null
+## Check subset and conditionally unseal or return null
 
 ``` c
 void* __capability
@@ -259,7 +259,7 @@ sealed and the latter being unsealed, if `a` can be derived from `b`,
 then it unseals `a` and returns it, otherwise it returns a null
 capability.
 
-### Check subset and conditionally unseal
+## Check subset and conditionally unseal
 
 ``` c
 void* __capability
@@ -271,7 +271,7 @@ Assuming two valid capabilities `a` and `b`, with the former being
 sealed and the latter being unsealed, if `a` can be derived from `b`,
 then it unseals `a` and returns it, otherwise it just returns `a`.
 
-### Convert pointer to capability offset (zeroing form)
+## Convert pointer to capability offset (zeroing form)
 
 ``` c
 void* __capability

--- a/morello/morello.md
+++ b/morello/morello.md
@@ -1,7 +1,7 @@
 ---
 title: Morello Supplement to the Arm C Language Extensions
-version: Development version based on 01alpha
-date-of-issue: TBD
+version: 02alpha
+date-of-issue: 11 January 2022
 # LaTeX specific variables
 copyright-text: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
 # Jekyll specific variables
@@ -150,12 +150,13 @@ All content in this document is at the **Alpha** quality level.
 
 ### Change History
 
-| Issue      | Date                  | Change                           |
-| :---       | :---                  | :---                             |
-| 00alpha    | 30th September 2020   | Alpha release                    |
-| 01alpha    | 02 July 2021          | Open source release. NFCI.       |
+| Issue      | Date                  | Change                                          |
+| :---       | :---                  | :---                                            |
+| 00alpha    | 30th September 2020   | Alpha release                                   |
+| 01alpha    | 02 July 2021          | Open source release. NFCI.                      |
+| 02alpha    | 11 January 2022       | See [Changes for 02alpha](#changes-for-02alpha) |
 
-## Changes for next release
+### Changes for 02alpha
 
 * Update the copyright statement in section [Copyright](#copyright).
 * Add a reference to the [CHERI-HYBRID](https://github.com/CTSRD-CHERI/cheri-hybrid-c-guide) *CHERI Hybrid C/C++ Programming Guide* in section [Scope](#scope).

--- a/mve_intrinsics/mve.md
+++ b/mve_intrinsics/mve.md
@@ -1,7 +1,7 @@
 ---
 title: Arm MVE Intrinsics
-version: Development version based on 2021Q2
-date-of-issue: TBD
+version: 2021Q4
+date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
@@ -109,15 +109,16 @@ Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.co
 
 ## Document history
 
-| Issue     | Date              | Change               |
-| :---      | :---              | :---                 |
-| Q219-00   | 30 June 2019      | Version ACLE Q2 2019 |
-| Q319-00   | 30 September 2019 | Version ACLE Q3 2019 |
-| Q419-00   | 31 December 2019  | Version ACLE Q4 2019 |
-| Q220-00   | 30 May 2020       | Version ACLE Q2 2020 |
-| 2021Q2    | 02 July 2021      | Open source release  |
+| Issue     | Date              | Change                                        |
+| :---      | :---              | :---                                          |
+| Q219-00   | 30 June 2019      | Version ACLE Q2 2019                          |
+| Q319-00   | 30 September 2019 | Version ACLE Q3 2019                          |
+| Q419-00   | 31 December 2019  | Version ACLE Q4 2019                          |
+| Q220-00   | 30 May 2020       | Version ACLE Q2 2020                          |
+| 2021Q2    | 02 July 2021      | Open source release                           |
+| 2021Q4    | 11 January 2022   | See [Changes for 2021Q4](#changes-for-2021q4) |
 
-### Changes for next release
+### Changes for 2021Q4
 
 * Update copyright statement in section [Copyright](#copyright).
 * Converted document sources from reStructuredText (`.rst`) to

--- a/mve_intrinsics/mve.md
+++ b/mve_intrinsics/mve.md
@@ -120,7 +120,7 @@ Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.co
 
 ### Changes for 2021Q4
 
-* Update copyright statement in section [Copyright](#copyright).
+* Updated copyright statement in section [Copyright](#copyright).
 * Converted document sources from reStructuredText (`.rst`) to
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the

--- a/mve_intrinsics/mve.template.md
+++ b/mve_intrinsics/mve.template.md
@@ -1,7 +1,7 @@
 ---
 title: Arm MVE Intrinsics
-version: Development version based on 2021Q2
-date-of-issue: TBD
+version: 2021Q4
+date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
@@ -109,15 +109,16 @@ Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.co
 
 ## Document history
 
-| Issue     | Date              | Change               |
-| :---      | :---              | :---                 |
-| Q219-00   | 30 June 2019      | Version ACLE Q2 2019 |
-| Q319-00   | 30 September 2019 | Version ACLE Q3 2019 |
-| Q419-00   | 31 December 2019  | Version ACLE Q4 2019 |
-| Q220-00   | 30 May 2020       | Version ACLE Q2 2020 |
-| 2021Q2    | 02 July 2021      | Open source release  |
+| Issue     | Date              | Change                                        |
+| :---      | :---              | :---                                          |
+| Q219-00   | 30 June 2019      | Version ACLE Q2 2019                          |
+| Q319-00   | 30 September 2019 | Version ACLE Q3 2019                          |
+| Q419-00   | 31 December 2019  | Version ACLE Q4 2019                          |
+| Q220-00   | 30 May 2020       | Version ACLE Q2 2020                          |
+| 2021Q2    | 02 July 2021      | Open source release                           |
+| 2021Q4    | 11 January 2022   | See [Changes for 2021Q4](#changes-for-2021q4) |
 
-### Changes for next release
+### Changes for 2021Q4
 
 * Update copyright statement in section [Copyright](#copyright).
 * Converted document sources from reStructuredText (`.rst`) to

--- a/mve_intrinsics/mve.template.md
+++ b/mve_intrinsics/mve.template.md
@@ -120,7 +120,7 @@ Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.co
 
 ### Changes for 2021Q4
 
-* Update copyright statement in section [Copyright](#copyright).
+* Updated copyright statement in section [Copyright](#copyright).
 * Converted document sources from reStructuredText (`.rst`) to
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the

--- a/neon_intrinsics/advsimd.md
+++ b/neon_intrinsics/advsimd.md
@@ -1,7 +1,7 @@
 ---
 title: Arm Neon Intrinsics Reference
-version: Development version based on 2021Q3
-date-of-issue: TBD
+version: 2021Q4
+date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: "Copyright: see section \\texorpdfstring{\\nameref{copyright}}{Copyright}."
@@ -111,23 +111,25 @@ for more information about Arm’s trademarks.
 
 ## Document history
 
-| Issue | Date            | Change               |
-| ----- | --------------- | -------------------- |
-| A     | 09 May 2014     | First release        |
-| B     | 24 March 2016   | Updated for ARMv8.1  |
-| C     | 30 March 2019   | Version ACLE Q1 2019 |
-| D     | 30 June 2019    | Version ACLE Q2 2019 |
-| E     | 30 Sept 2019    | Version ACLE Q3 2019 |
-| F     | 30 May 2020     | Version ACLE Q2 2020 |
-| G     | 30 October 2020 | Version ACLE Q3 2020 |
-| H     | 02 July 2021    | 2021Q2               |
+| Issue | Date              | Change               |
+| ----- | ----------------- | -------------------- |
+| A     | 09 May 2014       | First release        |
+| B     | 24 March 2016     | Updated for ARMv8.1  |
+| C     | 30 March 2019     | Version ACLE Q1 2019 |
+| D     | 30 June 2019      | Version ACLE Q2 2019 |
+| E     | 30 Sept 2019      | Version ACLE Q3 2019 |
+| F     | 30 May 2020       | Version ACLE Q2 2020 |
+| G     | 30 October 2020   | Version ACLE Q3 2020 |
+| H     | 02 July 2021      | 2021Q2               |
+| I     | 30 September 2021 | 2021Q3               |
+| J     | 11 January 2022   | 2021Q4               |
 
 ### Changes between 2021Q2 and 2021Q3
 
 * Fixed the guard macro for the base intrinsics.
 * Correct ``sdot``, ``udot`` and ``usdot`` specification on AArch32.
 
-### Changes for next release
+### Changes between 2021Q3 and 2021Q4.
 
 * Fix typo in signature of ``vaddq_s16``.
 * Update copyright statement in section [Copyright](#copyright).
@@ -135,6 +137,8 @@ for more information about Arm’s trademarks.
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the
   standard layout used in Arm specifications.
+* Add missing item for release 2021Q3 in the table with the list of
+  versions in section [Document history](#document-history).
 
 <!---
 **** Do not remove! ****

--- a/neon_intrinsics/advsimd.md
+++ b/neon_intrinsics/advsimd.md
@@ -127,17 +127,17 @@ for more information about Arm’s trademarks.
 ### Changes between 2021Q2 and 2021Q3
 
 * Fixed the guard macro for the base intrinsics.
-* Correct ``sdot``, ``udot`` and ``usdot`` specification on AArch32.
+* Corrected ``sdot``, ``udot`` and ``usdot`` specification on AArch32.
 
 ### Changes between 2021Q3 and 2021Q4.
 
-* Fix typo in signature of ``vaddq_s16``.
-* Update copyright statement in section [Copyright](#copyright).
+* Fixed typo in signature of ``vaddq_s16``.
+* Updated copyright statement in section [Copyright](#copyright).
 * Converted document sources from reStructuredText (`.rst`) to
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the
   standard layout used in Arm specifications.
-* Add missing item for release 2021Q3 in the table with the list of
+* Added missing item for release 2021Q3 in the table with the list of
   versions in section [Document history](#document-history).
 
 <!---

--- a/neon_intrinsics/advsimd.template.md
+++ b/neon_intrinsics/advsimd.template.md
@@ -1,7 +1,7 @@
 ---
 title: Arm Neon Intrinsics Reference
-version: Development version based on 2021Q3
-date-of-issue: TBD
+version: 2021Q4
+date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: "Copyright: see section \\texorpdfstring{{\\nameref{{copyright}}}}{{Copyright}}."
@@ -111,23 +111,25 @@ for more information about Arm’s trademarks.
 
 ## Document history
 
-| Issue | Date            | Change               |
-| ----- | --------------- | -------------------- |
-| A     | 09 May 2014     | First release        |
-| B     | 24 March 2016   | Updated for ARMv8.1  |
-| C     | 30 March 2019   | Version ACLE Q1 2019 |
-| D     | 30 June 2019    | Version ACLE Q2 2019 |
-| E     | 30 Sept 2019    | Version ACLE Q3 2019 |
-| F     | 30 May 2020     | Version ACLE Q2 2020 |
-| G     | 30 October 2020 | Version ACLE Q3 2020 |
-| H     | 02 July 2021    | 2021Q2               |
+| Issue | Date              | Change               |
+| ----- | ----------------- | -------------------- |
+| A     | 09 May 2014       | First release        |
+| B     | 24 March 2016     | Updated for ARMv8.1  |
+| C     | 30 March 2019     | Version ACLE Q1 2019 |
+| D     | 30 June 2019      | Version ACLE Q2 2019 |
+| E     | 30 Sept 2019      | Version ACLE Q3 2019 |
+| F     | 30 May 2020       | Version ACLE Q2 2020 |
+| G     | 30 October 2020   | Version ACLE Q3 2020 |
+| H     | 02 July 2021      | 2021Q2               |
+| I     | 30 September 2021 | 2021Q3               |
+| J     | 11 January 2022   | 2021Q4               |
 
 ### Changes between 2021Q2 and 2021Q3
 
 * Fixed the guard macro for the base intrinsics.
 * Correct ``sdot``, ``udot`` and ``usdot`` specification on AArch32.
 
-### Changes for next release
+### Changes between 2021Q3 and 2021Q4.
 
 * Fix typo in signature of ``vaddq_s16``.
 * Update copyright statement in section [Copyright](#copyright).
@@ -135,6 +137,8 @@ for more information about Arm’s trademarks.
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the
   standard layout used in Arm specifications.
+* Add missing item for release 2021Q3 in the table with the list of
+  versions in section [Document history](#document-history).
 
 <!---
 **** Do not remove! ****

--- a/neon_intrinsics/advsimd.template.md
+++ b/neon_intrinsics/advsimd.template.md
@@ -127,17 +127,17 @@ for more information about Arm’s trademarks.
 ### Changes between 2021Q2 and 2021Q3
 
 * Fixed the guard macro for the base intrinsics.
-* Correct ``sdot``, ``udot`` and ``usdot`` specification on AArch32.
+* Corrected ``sdot``, ``udot`` and ``usdot`` specification on AArch32.
 
 ### Changes between 2021Q3 and 2021Q4.
 
-* Fix typo in signature of ``vaddq_s16``.
-* Update copyright statement in section [Copyright](#copyright).
+* Fixed typo in signature of ``vaddq_s16``.
+* Updated copyright statement in section [Copyright](#copyright).
 * Converted document sources from reStructuredText (`.rst`) to
   Markdown (`.md`). The tool [`pandoc`](https://pandoc.org/) is now
   used to render the PDF of the specs. The PDF is rendered using the
   standard layout used in Arm specifications.
-* Add missing item for release 2021Q3 in the table with the list of
+* Added missing item for release 2021Q3 in the table with the list of
   versions in section [Document history](#document-history).
 
 <!---


### PR DESCRIPTION
# List of changes
1. Set release number
2. Fix sectioning of the Morello specifications. 

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have udated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] The pull request is done against the branch `next-release`.
