### PR TITLE
Require for MTE the __arm_mops_memset_tag intrinsic

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -215,7 +215,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   Q3 2021](#changes-between-acle-q2-2021-and-acle-q3-2021) by using
   the actual section title.
 
-#### Changes between ACLE Q3 2021 and ACLE Q4 2021
+#### Changes for next release
 
 * Updated the description of the `__arm_mops_memset_tag` intrinsic in [memcpy
   family of operations intrinsics - MOPS](#memcpy-family-of-operations-intrinsics---mops)

--- a/main/acle.md
+++ b/main/acle.md
@@ -1,7 +1,7 @@
 ---
 title: Arm C Language Extensions
-version: 2021Q4
-date-of-issue: 11 January 2021
+version: Development version based on 2021Q4
+date-of-issue: TBD
 # LaTeX specific variables
 copyright-text: Copyright 2011-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
 # Jekyll specific variables
@@ -214,6 +214,13 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Updated the section links in [Changes between ACLE Q2 2021 and ACLE
   Q3 2021](#changes-between-acle-q2-2021-and-acle-q3-2021) by using
   the actual section title.
+
+#### Changes between ACLE Q3 2021 and ACLE Q4 2021
+
+* Updated the description of the `__arm_mops_memset_tag` intrinsic in [memcpy
+  family of operations intrinsics - MOPS](#memcpy-family-of-operations-intrinsics---mops)
+  to require both the `__ARM_FEATURE_MOPS` and `__ARM_FEATURE_MEMORY_TAGGING`
+  feature macros.
 
 ### References
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -5145,7 +5145,8 @@ tagging.
 
 The `<arm_acle.h>` header should be included before using this intrinsic.
 
-This intrinsic is available when `__ARM_FEATURE_MOPS` is defined.
+This intrinsic is available when both `__ARM_FEATURE_MOPS` and
+`__ARM_FEATURE_MEMORY_TAGGING` are defined.
 
 ``` c
   void* __arm_mops_memset_tag(void* tagged_address, int value, size_t size)

--- a/main/design_documents/__ARM_FEATURE_MOPS.md
+++ b/main/design_documents/__ARM_FEATURE_MOPS.md
@@ -68,3 +68,9 @@ The parameters of `__arm_mops_memset_tag` are:
 * `value`: fill value.
 * `size`: number of bytes to fill. This should be a multiple of the tag
   granule size.
+
+As described by the [A64 ISA](https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SETGPT--SETGMT--SETGET--Memory-Set-with-tag-setting--unprivileged-?lang=en)
+the instructions for performing the memset with tag operation require both the
+MOPS and MTE extensions to be available. Therefore, the intrinsic should be
+available when both the `__ARM_FEATURE_MOPS` and `__ARM_FEATURE_MEMORY_TAGGING`
+feature macros are defined.


### PR DESCRIPTION
The execution of the `__arm_mops_memset_tag` introduced for the
Armv8.8-A/v9.3-A MOPS extension also requires the MTE extension to be
available.

This patch updates its description on the ACLE to require both
`__ARM_FEATURE_MOPS` and `__ARM_FEATURE_MEMORY_TAGGING` feature macros.

This fixes #160 
