### PR TITLE
[community] Improve PR template text.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ about: Technical issues, document format problems, bugs in scripts or feature pr
 
 ---
 
-<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 **Thank you for submitting a pull request!**
@@ -27,7 +27,6 @@ Please use the proposal label.
 As for any pull request, please make sure to go through the below
 checklist.
 
-
 Checklist: (mark with ``X`` those which apply)
 
 * [ ] If an issue reporting the bug exists, I have mentioned it in the
@@ -39,7 +38,7 @@ Checklist: (mark with ``X`` those which apply)
       (Please update existing copyright lines if applicable. You can
       specify year ranges with hyphen , as in `2017-2019`, and use
       commas to separate gaps, as in `2018-2020, 2022`).
-* [ ] I have udated the `Copyright` section of the sources of the
+* [ ] I have updated the `Copyright` section of the sources of the
       specification I have edited (this will show up in the text
       rendered in the PDF and other output format supported). The
       format is the same described in the previous item.
@@ -50,4 +49,15 @@ Checklist: (mark with ``X`` those which apply)
       worry if you cannot run these scripts on your machine, your
       patch will be automatically checked in the Actions of the pull
       request.
+* [ ] I have added an item that describes the changes I have
+      introduced in this PR in the section **Changes for next
+      release** of the section **Change Control**/**Document history**
+      of the document. Create **Changes for next release** if it does
+      not exist. Notice that changes that are not modifying the
+      content and rendering of the specifications (both HTML and PDF)
+      do not need to be listed.
+* [ ] When modifying content and/or its rendering, I have checked the
+      correctness of the result in the PDF output (please refer to the
+      instructions on [how to build the PDFs
+      locally](../CONTRIBUTING.md#continuous-integration)).
 * [ ] The pull request is done against the branch `next-release`.


### PR DESCRIPTION
1. Fix typo.

2. Add a checkbox on how to list the changes in the changelog.

3. Require to check the PDF output on content/style changes.

Fixes #165 


Checklist: (mark with ``X`` those which apply)

* [X] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [x] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [X] I have udated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] The pull request is done against the branch `next-release`.
