### PR TITLE
[ACLE] Improve PAC extension target feature macros example.

### DIFF
--- a/main/design_documents/pacbti-tfm.rst
+++ b/main/design_documents/pacbti-tfm.rst
@@ -67,6 +67,10 @@ Example (AArch32):
   #endif
   }
 
+A more practical example of these macros is in the stack-unwinding
+runtime for exceptions. In that case the runtime unwinding is improved
+by using ``AUTG`` rather than ``AUT`` because it frees up an
+additional register.
 
 Example (AArch64):
 --------
@@ -86,7 +90,3 @@ Example (AArch64):
     // No authentication required.
     asm ("ret");
   #endif
-
-A real-world use-case of these macros is in the stack-unwinding runtime for
-exceptions where the runtime unwinding is potentially better with ``AUTG``
-rather than using ``AUT`` which forces register pressure.

--- a/main/design_documents/pacbti-tfm.rst
+++ b/main/design_documents/pacbti-tfm.rst
@@ -1,5 +1,5 @@
 ..
-   SPDX-FileCopyrightText: Copyright 2021 Arm Limited <open-source-office@arm.com>
+   SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited <open-source-office@arm.com>
 
    CC-BY-SA-4.0 AND Apache-Patent-License
    See LICENSE.md file for details
@@ -44,7 +44,7 @@ application is built to run on legacy and be backward compatible, ``PAC`` can be
 used. Contrarily, ``PACG`` can be used only when ``PACBTI`` target extension is
 implemented.
 
-Example:
+Example (AArch32):
 --------
 
 ::
@@ -66,6 +66,26 @@ Example:
     asm ("AUT R12, LR, SP");
   #endif
   }
+
+
+Example (AArch64):
+--------
+
+::
+
+  #if __ARM_FEATURE_PAC_DEFAULT
+    // Authenticated return required.
+  # if __ARM_FEATURE_PAUTH
+    // Have PAUTH instructions
+    asm ("retaa");
+  # else
+    // Use authentication from NOP space.
+    asm ("autiasp;ret");
+  # endif
+  #else
+    // No authentication required.
+    asm ("ret");
+  #endif
 
 A real-world use-case of these macros is in the stack-unwinding runtime for
 exceptions where the runtime unwinding is potentially better with ``AUTG``


### PR DESCRIPTION
This patch renames pacbti-m-tfm.rst to make it non limited to the cortex-m scope and improves one example related to PAC extension target feature macros.


* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [x] I have udated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] The pull request is done against the branch `next-release`.