### PR TITLE
[community] Checkbox for list of contributors.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -61,3 +61,5 @@ Checklist: (mark with ``X`` those which apply)
       instructions on [how to build the PDFs
       locally](../CONTRIBUTING.md#continuous-integration)).
 * [ ] The pull request is done against the branch `next-release`.
+* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
+      in the [README](../README.md#contributors-) page of the project.


### PR DESCRIPTION
We ask contributors to explicitly state if they don't want to get
added to the list of contributors, which shows up at https://github.com/ARM-software/acle#contributors-

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have udated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] The pull request is done against the branch `next-release`.
