### PR TITLE
[main] Improve the description of the cryptographic extensions.

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -272,6 +272,11 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added a description of support levels in [Current Status and
   Anticipated Changes](#current-status-and-anticipated-changes).
 * Support added for [Function Multi Versioning](#function-multi-versioning).
+* The sections [AES extension](#aes-extension), [SHA2
+  extension](#sha2-extension) and [SHA512
+  extension](#sha512-extension) have been reworded for clarity, by
+  specifying the `FEAT_*` tag they refer to from the Arm Architectural
+  Reference Manual.
 
 ### References
 
@@ -1503,21 +1508,28 @@ instructions include AES{E, D}, SHA1{C, P, M} and others. This also implies
 
 #### AES extension
 
-`__ARM_FEATURE_AES` is defined to 1 if the AES Crypto instructions from
-Armv8-A are supported and intrinsics targeting them are available. These
-instructions include AES{E, D}, AESMC, AESIMC and others.
+`__ARM_FEATURE_AES` is defined to 1 if the AES Crypto instructions
+from Armv8-A are supported and intrinsics targeting them are
+available. These instructions are identified by `FEAT_AES` and
+`FEAT_PMULL` in [[ARMARMv8]](#ARMARMv8), and they include AES{E, D},
+AESMC, AESIMC and others.
 
 #### SHA2 extension
 
-`__ARM_FEATURE_SHA2` is defined to 1 if the SHA1 & SHA2 Crypto instructions
-from Armv8-A are supported and intrinsics targeting them are available. These
-instructions include SHA1{C, P, M} and others.
+`__ARM_FEATURE_SHA2` is defined to 1 if the SHA1 & SHA2 Crypto
+instructions from Armv8-A are supported and intrinsics targeting them
+are available. These instructions are identified by `FEAT_SHA1` and
+`FEAT_SHA256` in [[ARMARMv8]](#ARMARMv8), and they include SHA1{C, P,
+M}, SHA256H, SHA256H2... and others.
 
 #### SHA512 extension
 
 `__ARM_FEATURE_SHA512` is defined to 1 if the SHA2 Crypto instructions
-from Armv8.2-A are supported and intrinsics targeting them are available. These
-instructions include SHA1{C, P, M} and others.
+from Armv8.2-A are supported and intrinsics targeting them are
+available. These instructions are identified by `FEAT_SHA512` in
+[[ARMARMv82]](#ARMARMv82), and they include SHA1{C, P, M}, SHA256H,
+SHA256H2, ..., SHA512H, SHA512H2, SHA512SU0... and others. Notice that
+`FEAT_SHA512` requires both `FEAT_SHA1` and `FEAT_SHA256`.
 
 #### SHA3 extension
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -1516,7 +1516,7 @@ AESMC, AESIMC and others.
 
 #### SHA2 extension
 
-`__ARM_FEATURE_SHA2` is defined to 1 if the SHA1 & SHA2 Crypto
+`__ARM_FEATURE_SHA2` is defined to 1 if the SHA1 & SHA2-256 Crypto
 instructions from Armv8-A are supported and intrinsics targeting them
 are available. These instructions are identified by `FEAT_SHA1` and
 `FEAT_SHA256` in [[ARMARMv8]](#ARMARMv8), and they include SHA1{C, P,
@@ -1524,7 +1524,7 @@ M}, SHA256H, SHA256H2... and others.
 
 #### SHA512 extension
 
-`__ARM_FEATURE_SHA512` is defined to 1 if the SHA2 Crypto instructions
+`__ARM_FEATURE_SHA512` is defined to 1 if the SHA2-512 Crypto instructions
 from Armv8.2-A are supported and intrinsics targeting them are
 available. These instructions are identified by `FEAT_SHA512` in
 [[ARMARMv82]](#ARMARMv82), and they include SHA1{C, P, M}, SHA256H,


### PR DESCRIPTION
In the Q2 2018 version of the document, __ARM_FEATURE_CRYPTO was
deprecated in favor of finer-grained __ARM_FEATURE_AES,
__ARM_FEATURE_SHA2 and __ARM_FEATURE_SHA512 flags. But the ARM
cryptography extension originally covered four features: FEAT_AES,
FEAT_PMULL, FEAT_SHA1, and FEAT_SHA256.

This has generated some confusion, as for example it was not clear if
FEAT_PMULL was included under __ARM_FEATURE_AES.

Specifically, the ArmArm [1], issue G.b released on 22 July 2021, on
page A2-72 says:

    The AES functionality, including support for multiplication of
    64-bit polynomials. The ID_AA64ISAR0_EL1.AES field indicates
    whether this functionality is supported.

This means that FEAT_AES and FEAT_PMULL need to be paired together in
an implementation.

[1] https://developer.arm.com/documentation/ddi0487/latest

Crypto extension overview
=========================

With respect to [1], issue G.b released on 22 July 2021.

Armv8.0 cryptographic extensions
--------------------------------

From C3.5.30 and A2.3 we gather the following:

    1. Table C3-96: Cryptographic Extension of Armv8.0 consist of
       FEAT_AES + FEAT_PMULL + FEAT_SHA1 + FEAT_SHA256

    2. Each of FEAT_* is made by the following instrucions:

       FEAT_AES = { AESD, AESE, AESIMC, AESMC }
       FEAT_PMULL =  { PMULL }
       FEAT_SHA1 = {SHA1C, SHA1H, SHA1M, SHA1P, SHA1SU0, SHA1SU1}
       FEAT_SHA256 = {SHA256H, SHA256H2, SHA256SU0, SHA256SU1}

The term SHA2-256 is an alias for the feature FEAT_SHA256:

    > The SHA1 and SHA2-256 functionality. The ID_AA64ISAR0_EL1.{SHA2,
    > SHA1} fields indicate whether this functionality is supported.

Armv8.2 cryptographic extensions
--------------------------------

From A2.3.1, these consist of FEAT_SHA512 + FEAT_SHA3 + FEAT_SM3 +
FEAT_SM4.

Requirements:

    1. FEAT_SHA512 require FEAT_SHA1 and FEAT_SHA256
    2. FEAT_SHA3 require FEAT_SHA1 and FEAT_SHA256

The features consist of the following instructions:

    FEAT_SHA512 = {SHA512H, SHA512H2, SHA512SU0, SHA512SU1 }
    FEAT_SHA3 = {EOR3, RAX1, XAR, BCAX}
    FEAT_SM3 = { SM3SS1, SM3TT1A, SM3TT1B, SM3TT2A, SM3TT2B, SM3PARTW1, SM3PARTW2 }
    FEAT_SM4 = { SM4E, SM4EKEY }

At the same time, on page pag C3-279 says:

    > Implementation of FEAT_SHA512 requires the implementation of the
    > SHA1 and SHA2-256 instructions from the Armv8.0 Cryptographic
    > Extension.

This means that FEAT_SHA512 require FEAT_SHA1 and FEAT_SHA256.

----------------------------------------------------------------------------------

This patch fixes issue https://github.com/ARM-software/acle/issues/152


Checklist: (mark with ``X`` those which apply)

* [X] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have udated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] The pull request is done against the branch `next-release`.
