### PR TITLE
[pdf] Add draft watermark for the development versions.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,5 +60,7 @@ Checklist: (mark with ``X`` those which apply)
       correctness of the result in the PDF output (please refer to the
       instructions on [how to build the PDFs
       locally](../CONTRIBUTING.md#continuous-integration)).
+* [ ] The variable `draftversion` is set to `true` in the YAML header
+      of the sources of the specifications I have modified.
 * [ ] Please *DO NOT* add my GitHub profile to the list of contributors
       in the [README](../README.md#contributors-) page of the project.

--- a/main/acle.md
+++ b/main/acle.md
@@ -1,9 +1,10 @@
 ---
 title: Arm C Language Extensions
-version: Development version based on 2021Q4
-date-of-issue: TBD
+version: 2021Q4
+date-of-issue: 11 January 2022
 # LaTeX specific variables
 copyright-text: Copyright 2011-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/morello/morello.md
+++ b/morello/morello.md
@@ -4,6 +4,7 @@ version: 02alpha
 date-of-issue: 11 January 2022
 # LaTeX specific variables
 copyright-text: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/mve_intrinsics/mve.md
+++ b/mve_intrinsics/mve.md
@@ -5,6 +5,7 @@ date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/mve_intrinsics/mve.template.md
+++ b/mve_intrinsics/mve.template.md
@@ -5,6 +5,7 @@ date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/neon_intrinsics/advsimd.md
+++ b/neon_intrinsics/advsimd.md
@@ -5,6 +5,7 @@ date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: "Copyright: see section \\texorpdfstring{\\nameref{copyright}}{Copyright}."
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/neon_intrinsics/advsimd.template.md
+++ b/neon_intrinsics/advsimd.template.md
@@ -5,6 +5,7 @@ date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: "Copyright: see section \\texorpdfstring{{\\nameref{{copyright}}}}{{Copyright}}."
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/tools/acle_template.tex
+++ b/tools/acle_template.tex
@@ -1,4 +1,5 @@
 % Copyright (c) 2014--2021, John MacFarlane
+% SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 % Based on default.latex template released with Pandoc (www.pandoc.org).
 % License: BSD 3-clause
 % See `data/templates` in `COPYRIGHT` at https://github.com/jgm/pandoc
@@ -33,11 +34,17 @@
 \makeatother
 
 \sectionfont{\color{armblue}}
+$if(draftversion)$
+\newcommand{\versiontext}{\textcolor{red}{Development version based on $version$}}
+$else$
+\newcommand{\versiontext}{$version$}
+$endif$
+\newcommand{\dateofissue}{$if(draftversion)$TBD$else$$date-of-issue$$endif$}
 
 \pagestyle{fancy}
 \fancyhf{}
 \fancyhead[L]{\small $title$ \\~}
-\fancyhead[R]{\small Version: $version$ \\ \currentname}
+\fancyhead[R]{\small Version: \versiontext \\ \currentname}
 \fancyfoot[C]{\small \emph{$copyright-text$}}
 \fancyfoot[R]{\small ~\\ Page \textbf{\thepage}\ of  \textbf{\pageref*{LastPage}}}
 \renewcommand{\footrulewidth}{0pt}
@@ -46,7 +53,7 @@
 \fancypagestyle{plain}{%
   \fancyhf{}
   \fancyhead[L]{\small $title$ \\~}
-  \fancyhead[R]{\small Version: $version$ \\ \currentname}
+  \fancyhead[R]{\small Version: \versiontext \\ \currentname}
   \fancyfoot[C]{\small \emph{$copyright-text$}}
   \fancyfoot[R]{\small ~\\ Page \textbf{\thepage}\ of  \textbf{\pageref*{LastPage}}}
   \renewcommand{\footrulewidth}{0pt}
@@ -73,7 +80,7 @@ $endif$
 \setcounter{tocdepth}{6}
 \setcounter{secnumdepth}{6}
 
-\date{$date-of-issue$}
+\date{\dateofissue}
 
 \hypersetup{
             colorlinks=true,
@@ -105,8 +112,8 @@ $endif$
         \end{minipage}
         \begin{minipage}[t]{14.0cm}
             {\huge \bfseries  $title$}\\[2ex]
-            {\large Release Date: $date-of-issue$}\\[2ex]
-            {\large \bfseries Version: $version$}\\[3ex]
+            {\large Release Date: \dateofissue}\\[2ex]
+            {\large \bfseries Version: \versiontext}\\[3ex]
         \end{minipage}
         \newline
         \begin{minipage}[t][0.47cm][t]{\linewidth}


### PR DESCRIPTION
Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [x] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](../CONTRIBUTING.md#continuous-integration)).
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](../README.md#contributors-) page of the project.
