### PR TITLE
Add documentation for aarch64_sve_pcs attribute

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -2278,7 +2278,9 @@ is a function that returns results in such registers, it must ensure that the
 entire contents of `z8-z23` and `p4-15` are preserved across the call. This
 calling convention is described in sections 6.1.3 and 6.1.4 of
 [AAPCS64](#AAPCS64) (see [release 2022Q1](https://github.com/ARM-software/abi-aa/releases/tag/2022Q1)).
-The ACLE allows this to be enforced per function:
+
+The ACLE allows this to be enforced per function by adding the following
+function attribute to a function declaration or definition:
 
 ``` c
     __attribute__(("aarch64_sve_pcs"))

--- a/main/acle.md
+++ b/main/acle.md
@@ -2271,7 +2271,7 @@ arrays with arbitrarily aligned elements
 
 ## Scalable Vector Extension procedure call standard attribute
 
-On SVE enabled AArch64 targets, the [[AAPCS64]](#AAPCS64) allows for procedure
+On SVE enabled AArch64 targets, the [[AAPCS64]](#AAPCS64) allows procedure
 calls to use the SVE calling convention. If a subroutine takes at least one
 argument in scalable vector registers or scalable predicate registers, or if
 the subroutine is a function that returns results in such registers, the

--- a/main/acle.md
+++ b/main/acle.md
@@ -4,7 +4,7 @@ version: 2022Q1
 date-of-issue: 06 April 2022
 # LaTeX specific variables
 copyright-text: Copyright 2011-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true
@@ -296,6 +296,11 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   No functional change intended.
 * Reordered the sections in [Change history](#change-history) in
   chronological order.
+
+#### Changes for next release
+
+* Added section Scalable Vector Extension procedure call standard
+  for attribute [aarch64_sve_pcs](#scalable-vector-extension-procedure-call-standard)
 
 ### References
 
@@ -2264,6 +2269,19 @@ is implementation-defined.
 
 The generic itanium C++ ABI, which we use in AArch64, already handles
 arrays with arbitrarily aligned elements
+
+## Scalable Vector Extension procedure call standard
+
+On SVE enabled AArch64 targets, the [[AAPCS]](#AAPCS) allows for procedure
+calls to use the SVE calling convention. If a subroutine takes at least one
+argument in scalable vector registers or scalable predicate registers, or if it
+is a function that returns results in such registers, it must ensure that the
+entire contents of z8-z23 and p4-15 are preserved across the call. The ACLE
+allows this to be enforced per function:
+
+``` c
+    __attribute__(("aarch64_sve_pcs"))
+```
 
 ## Other attributes
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -2273,13 +2273,13 @@ arrays with arbitrarily aligned elements
 
 On SVE enabled AArch64 targets, the [[AAPCS64]](#AAPCS64) allows for procedure
 calls to use the SVE calling convention. If a subroutine takes at least one
-argument in scalable vector registers or scalable predicate registers, or if it
-is a function that returns results in such registers, it must ensure that the
-entire contents of `z8-z23` and `p4-15` are preserved across the call. This
-calling convention is described in sections 6.1.3 and 6.1.4 of
-[AAPCS64](#AAPCS64) (see [release 2022Q1](https://github.com/ARM-software/abi-aa/releases/tag/2022Q1)).
+argument in scalable vector registers or scalable predicate registers, or if
+the subroutine is a function that returns results in such registers, the
+subroutine must ensure that the entire contents of `z8-z23` and `p4-15` are
+preserved across the call. This calling convention is described in sections
+6.1.3 and 6.1.4 of [AAPCS64](#AAPCS64) (see [release 2022Q1](https://github.com/ARM-software/abi-aa/releases/tag/2022Q1)).
 
-The ACLE allows this to be enforced per function by adding the following
+The ACLE allows this to be enforced per function and adds the following
 function attribute to a function declaration or definition:
 
 ``` c

--- a/main/acle.md
+++ b/main/acle.md
@@ -300,7 +300,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 #### Changes for next release
 
 * Added section Scalable Vector Extension procedure call standard
-  for attribute [aarch64_sve_pcs](#scalable-vector-extension-procedure-call-standard)
+  for attribute [aarch64_sve_pcs](#scalable-vector-extension-procedure-call-standard-attribute)
 
 ### References
 
@@ -2270,14 +2270,16 @@ is implementation-defined.
 The generic itanium C++ ABI, which we use in AArch64, already handles
 arrays with arbitrarily aligned elements
 
-## Scalable Vector Extension procedure call standard
+## Scalable Vector Extension procedure call standard attribute
 
 On SVE enabled AArch64 targets, the [[AAPCS]](#AAPCS) allows for procedure
 calls to use the SVE calling convention. If a subroutine takes at least one
 argument in scalable vector registers or scalable predicate registers, or if it
 is a function that returns results in such registers, it must ensure that the
-entire contents of z8-z23 and p4-15 are preserved across the call. The ACLE
-allows this to be enforced per function:
+entire contents of `z8-z23` and `p4-15` are preserved across the call. This calling
+convention is described in sections 6.1.3 and 6.1.4 of aapcs64 of [AAPCS
+2022Q1](https://github.com/ARM-software/abi-aa/releases/tag/2022Q1).
+The ACLE allows this to be enforced per function:
 
 ``` c
     __attribute__(("aarch64_sve_pcs"))

--- a/main/acle.md
+++ b/main/acle.md
@@ -299,8 +299,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 
 #### Changes for next release
 
-* Added section Scalable Vector Extension procedure call standard
-  for attribute [aarch64_sve_pcs](#scalable-vector-extension-procedure-call-standard-attribute)
+* Added section [Scalable Vector Extension procedure call standard attribute](#scalable-vector-extension-procedure-call-standard-attribute)
 
 ### References
 
@@ -2272,13 +2271,13 @@ arrays with arbitrarily aligned elements
 
 ## Scalable Vector Extension procedure call standard attribute
 
-On SVE enabled AArch64 targets, the [[AAPCS]](#AAPCS) allows for procedure
+On SVE enabled AArch64 targets, the [[AAPCS64]](#AAPCS64) allows for procedure
 calls to use the SVE calling convention. If a subroutine takes at least one
 argument in scalable vector registers or scalable predicate registers, or if it
 is a function that returns results in such registers, it must ensure that the
-entire contents of `z8-z23` and `p4-15` are preserved across the call. This calling
-convention is described in sections 6.1.3 and 6.1.4 of aapcs64 of [AAPCS
-2022Q1](https://github.com/ARM-software/abi-aa/releases/tag/2022Q1).
+entire contents of `z8-z23` and `p4-15` are preserved across the call. This
+calling convention is described in sections 6.1.3 and 6.1.4 of
+[AAPCS64](#AAPCS64) (see [release 2022Q1](https://github.com/ARM-software/abi-aa/releases/tag/2022Q1)).
 The ACLE allows this to be enforced per function:
 
 ``` c

--- a/main/design_documents/aarch64_sve_pcs.md
+++ b/main/design_documents/aarch64_sve_pcs.md
@@ -5,15 +5,15 @@ parameters or has them as return values (“SVE-aware functions”). This pushes
 the responsibility of preserving the majority of the SVE state onto the callee,
 which is in a better position to know if a given register is to be clobbered
 and therefore requires preservation. When an SVE-aware function calls an
-SVE-unaware function, it is necessary to preserve the whole SVE register state
+SVE-unaware function, the caller must preserve the whole SVE register state
 going into the function, since the use of NEON or floating-point instructions
 may clobber the upper bits of the SVE state.
 
-Calling out to instrumentation functions which do not have SVE in their function
-signature, for example performance monitoring or `printf`, causes the whole
-register state to be preserved across the call, which requires lots of
-additional instructions.
+Calls out to instrumentation functions which do not have SVE in their function
+signature, (for example performance monitoring or `printf`), causes the whole
+register state to be preserved across the call, which requires many additional
+instructions.
 
-To avoid the cost of preserving the whole SVE register state it is necessary to
-have a way of explicitly specifying that a function will take on the
-responsibility of preserving the SVE register state across the call.
+To avoid the cost of preserving the whole SVE register state you must have
+the option to ensure a function will take on the responsibility of preserving
+the SVE register state across the call.

--- a/main/design_documents/aarch64_sve_pcs.md
+++ b/main/design_documents/aarch64_sve_pcs.md
@@ -1,0 +1,27 @@
+# Design Document for aarch64_sve_pcs
+
+This patch proposes the introduction of aarch64_sve_pcs.
+
+The AArch64 ABI specifies a behaviour for functions which take SVE types as
+parameters or has them as return values (“SVE-aware functions”). This pushes
+the responsibility of preserving the majority of the SVE state onto the callee,
+which is in a better position to know if a given register is to be clobbered
+and therefore requires preservation. When an SVE-aware function calls an
+SVE-unaware function, it’s necessary to preserve the whole SVE register state
+going into the function, since the use of NEON or floating-point instructions
+may clobber the upper bits of the SVE state.
+
+Calling out to instrumentation functions which don’t have SVE in their function
+signature, for example performance monitoring or printf, causes the whole
+register state to be preserved across the call, which requires lots of
+additional instructions.
+
+To avoid the cost of preserving the whole SVE register state it’s necessary to
+have a way of explicitly specifying that a function will take on the
+responsibility of preserving the SVE register state across the call. This patch
+introduces aarch64_sve_pcs for this purpose.
+
+The attribute can be given to functions as follows:
+``` c
+    __attribute__(("aarch64_sve_pcs"))
+```

--- a/main/design_documents/aarch64_sve_pcs.md
+++ b/main/design_documents/aarch64_sve_pcs.md
@@ -10,7 +10,7 @@ going into the function, since the use of NEON or floating-point instructions
 may clobber the upper bits of the SVE state.
 
 Calling out to instrumentation functions which do not have SVE in their function
-signature, for example performance monitoring or printf, causes the whole
+signature, for example performance monitoring or `printf`, causes the whole
 register state to be preserved across the call, which requires lots of
 additional instructions.
 

--- a/main/design_documents/aarch64_sve_pcs.md
+++ b/main/design_documents/aarch64_sve_pcs.md
@@ -1,27 +1,19 @@
-# Design Document for aarch64_sve_pcs
-
-This patch proposes the introduction of aarch64_sve_pcs.
+# Design Document for `aarch64_sve_pcs`
 
 The AArch64 ABI specifies a behaviour for functions which take SVE types as
 parameters or has them as return values (“SVE-aware functions”). This pushes
 the responsibility of preserving the majority of the SVE state onto the callee,
 which is in a better position to know if a given register is to be clobbered
 and therefore requires preservation. When an SVE-aware function calls an
-SVE-unaware function, it’s necessary to preserve the whole SVE register state
+SVE-unaware function, it is necessary to preserve the whole SVE register state
 going into the function, since the use of NEON or floating-point instructions
 may clobber the upper bits of the SVE state.
 
-Calling out to instrumentation functions which don’t have SVE in their function
+Calling out to instrumentation functions which do not have SVE in their function
 signature, for example performance monitoring or printf, causes the whole
 register state to be preserved across the call, which requires lots of
 additional instructions.
 
-To avoid the cost of preserving the whole SVE register state it’s necessary to
+To avoid the cost of preserving the whole SVE register state it is necessary to
 have a way of explicitly specifying that a function will take on the
-responsibility of preserving the SVE register state across the call. This patch
-introduces aarch64_sve_pcs for this purpose.
-
-The attribute can be given to functions as follows:
-``` c
-    __attribute__(("aarch64_sve_pcs"))
-```
+responsibility of preserving the SVE register state across the call.


### PR DESCRIPTION
Add documentation for the aarch64_sve_pcs attribute, which allows manual
enforcement of the SVE procedure call standard on functions


Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](../CONTRIBUTING.md#continuous-integration)).
* [x] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](../README.md#contributors-) page of the project.
