### PR TITLE
[main] expand SVE_VECTOR_OPERATORS to include sizeless vectors

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -1509,23 +1509,33 @@ SVE language extensions:
 > [The __ARM_FEATURE_SVE_BITS macro](#the-__arm_feature_sve_bits-macro)
 > for details.
 
-**`__ARM_FEATURE_SVE_VECTOR_OPERATORS==1`**
+**`__ARM_FEATURE_SVE_VECTOR_OPERATORS==N`**
 
-> This indicates that applying the `arm_sve_vector_bits` attribute
+> `N >= 1` indicates that applying the `arm_sve_vector_bits` attribute
 > to an SVE vector type creates a type that supports the GNU vector
-> extensions. The state of this macro is only meaningful when
+> extensions. This condition is only meaningful when
 > `__ARM_FEATURE_SVE_BITS` is nonzero. See [`arm_sve_vector_bits` behavior
 > specific to vectors](#arm_sve_vector_bits-behavior-specific-to-vectors)
 > for details.
 
+> `N >= 2` indicates that the operators outlined in the GNU vector
+> extensions additionally work on sizeless SVE vector types like `svint32_t`.
+> The availability of operators on sizeless types is independent of
+> `__ARM_FEATURE_SVE_BITS`.
+
 **`__ARM_FEATURE_SVE_PREDICATE_OPERATORS==1`**
 
-> This indicates that applying the `arm_sve_vector_bits` attribute to
+> `N >= 1` indicates that applying the `arm_sve_vector_bits` attribute to
 > `svbool_t` creates a type that supports basic built-in vector operations.
 > The state of this macro is only meaningful when `__ARM_FEATURE_SVE_BITS`
 > is nonzero. See [`arm_sve_vector_bits` behavior specific to
 > predicates](#arm_sve_vector_bits-behavior-specific-to-predicates)
 > for details.
+
+> `N >= 2` indicates that the built-in vector operations described above
+> additionally work on `svbool_t`.
+> The availability of operators on `svbool_t` is independent of
+> `__ARM_FEATURE_SVE_BITS`.
 
 #### SVE2
 
@@ -1990,8 +2000,8 @@ be found in [[BA]](#BA).
 | [`__ARM_FEATURE_SVE_MATMUL_FP32`](#multiplication-of-32-bit-floating-point-matrices)                                                                    | 32-bit floating-point matrix multiply extension (FEAT_F32MM)                                       | 1           |
 | [`__ARM_FEATURE_SVE_MATMUL_FP64`](#multiplication-of-64-bit-floating-point-matrices)                                                                    | 64-bit floating-point matrix multiply extension (FEAT_F64MM)                                       | 1           |
 | [`__ARM_FEATURE_SVE_MATMUL_INT8`](#multiplication-of-8-bit-integer-matrices)                                                                            | SVE support for the integer matrix multiply extension (FEAT_I8MM)                                  | 1           |
-| [`__ARM_FEATURE_SVE_PREDICATE_OPERATORS`](#scalable-vector-extension-sve)                                                                               | C and C++ operators support fixed-length SVE predicate types                                       | 1           |
-| [`__ARM_FEATURE_SVE_VECTOR_OPERATORS`](#scalable-vector-extension-sve)                                                                                  | C and C++ operators support fixed-length SVE vector types                                          | 1           |
+| [`__ARM_FEATURE_SVE_PREDICATE_OPERATORS`](#scalable-vector-extension-sve)                                                                               | Level of support for C and C++ operators on SVE vector types                                        | 1           |
+| [`__ARM_FEATURE_SVE_VECTOR_OPERATORS`](#scalable-vector-extension-sve)                                                                                  | Level of support for C and C++ operators on SVE predicate types                                     | 1           |
 | [`__ARM_FEATURE_SVE2`](#sve2)                                                                                                                           | SVE version 2 (FEAT_SVE2)                                                                          | 1           |
 | [`__ARM_FEATURE_SVE2_AES`](#aes-extension)                                                                                                              | SVE2 support for the AES crytographic extension (FEAT_SVE_AES)                                     | 1           |
 | [`__ARM_FEATURE_SVE2_BITPERM`](#bit-permute-extension)                                                                                                  | SVE2 bit permute extension (FEAT_SVE2_BitPerm)                                                     | 1           |


### PR DESCRIPTION
To guard usage of C/C++ operators on sizeless SVE vectors, we should
expand __ARM_FEATURE_SVE_VECTOR_OPERATORS to include sizeless vectors
and __ARM_FEATURE_SVE_PREDICATE_OPERATORS to include predicate vectors.

It's possible that we also need something in the spec to explain what
these operators do, but right now I would like to get consensus on
what the feature macro should look like so we can add it to clang and
gcc before people start using the operators without it.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](../CONTRIBUTING.md), in particular the section on [submitting
a proposal](../CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](../CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](../README.md#contributors-) page of the project.
