### PR TITLE
[main] Add an _m suffix to some SME intrinsics

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -9134,130 +9134,130 @@ Replacing `_hor` with `_ver` gives the associated vertical forms.
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svaddha_za32[_s32](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svint32_t zn);
+  void svaddha_za32[_s32]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svint32_t zn);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svaddha_za32[_u32](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svuint32_t zn);
-
-  // Only if __ARM_FEATURE_SME_I16I64 != 0
-  __attribute__((arm_streaming, arm_shared_za))
-  void svaddha_za64[_s64](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svint64_t zn);
+  void svaddha_za32[_u32]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svuint32_t zn);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svaddha_za64[_u64](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svuint64_t zn);
+  void svaddha_za64[_s64]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svint64_t zn);
+
+  // Only if __ARM_FEATURE_SME_I16I64 != 0
+  __attribute__((arm_streaming, arm_shared_za))
+  void svaddha_za64[_u64]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svuint64_t zn);
 ```
 
 #### ADDVA
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svaddva_za32[_s32](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svint32_t zn);
+  void svaddva_za32[_s32]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svint32_t zn);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svaddva_za32[_u32](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svuint32_t zn);
-
-  // Only if __ARM_FEATURE_SME_I16I64 != 0
-  __attribute__((arm_streaming, arm_shared_za))
-  void svaddva_za64[_s64](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svint64_t zn);
+  void svaddva_za32[_u32]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svuint32_t zn);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svaddva_za64[_u64](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svuint64_t zn);
+  void svaddva_za64[_s64]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svint64_t zn);
+
+  // Only if __ARM_FEATURE_SME_I16I64 != 0
+  __attribute__((arm_streaming, arm_shared_za))
+  void svaddva_za64[_u64]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svuint64_t zn);
 ```
 
 #### BFMOPA, FMOPA (widening), SMOPA, UMOPA
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za32[_bf16](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svbfloat16_t zn, svbfloat16_t zm);
+  void svmopa_za32[_bf16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svbfloat16_t zn, svbfloat16_t zm);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za32[_f16](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svfloat16_t zn, svfloat16_t zm);
+  void svmopa_za32[_f16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svfloat16_t zn, svfloat16_t zm);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za32[_s8](uint64_t tile, svbool_t pn, svbool_t pm,
-                        svint8_t zn, svint8_t zm);
+  void svmopa_za32[_s8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                          svint8_t zn, svint8_t zm);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za32[_u8](uint64_t tile, svbool_t pn, svbool_t pm,
-                        svuint8_t zn, svuint8_t zm);
-
-  // Only if __ARM_FEATURE_SME_I16I64 != 0
-  __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za64[_s16](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svint16_t zn, svint16_t zm);
+  void svmopa_za32[_u8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                          svuint8_t zn, svuint8_t zm);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za64[_u16](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svuint16_t zn, svuint16_t zm);
+  void svmopa_za64[_s16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svint16_t zn, svint16_t zm);
+
+  // Only if __ARM_FEATURE_SME_I16I64 != 0
+  __attribute__((arm_streaming, arm_shared_za))
+  void svmopa_za64[_u16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svuint16_t zn, svuint16_t zm);
 ```
 
 #### FMOPA (non-widening)
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za32[_f32](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svfloat32_t zn, svfloat32_t zm);
+  void svmopa_za32[_f32]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svfloat32_t zn, svfloat32_t zm);
 
   // Only if __ARM_FEATURE_SME_F64F64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svmopa_za64[_f64](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svfloat64_t zn, svfloat64_t zm);
+  void svmopa_za64[_f64]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svfloat64_t zn, svfloat64_t zm);
 ```
 
 #### BFMOPS, FMOPS (widening), SMOPS, UMOPS
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za32[_bf16](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svbfloat16_t zn, svbfloat16_t zm);
+  void svmops_za32[_bf16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svbfloat16_t zn, svbfloat16_t zm);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za32[_f16](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svfloat16_t zn, svfloat16_t zm);
+  void svmops_za32[_f16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svfloat16_t zn, svfloat16_t zm);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za32[_s8](uint64_t tile, svbool_t pn, svbool_t pm,
-                        svint8_t zn, svint8_t zm);
+  void svmops_za32[_s8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                          svint8_t zn, svint8_t zm);
 
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za32[_u8](uint64_t tile, svbool_t pn, svbool_t pm,
-                        svuint8_t zn, svuint8_t zm);
-
-  // Only if __ARM_FEATURE_SME_I16I64 != 0
-  __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za64[_s16](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svint16_t zn, svint16_t zm);
+  void svmops_za32[_u8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                          svuint8_t zn, svuint8_t zm);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za64[_u16](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svuint16_t zn, svuint16_t zm);
+  void svmops_za64[_s16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svint16_t zn, svint16_t zm);
+
+  // Only if __ARM_FEATURE_SME_I16I64 != 0
+  __attribute__((arm_streaming, arm_shared_za))
+  void svmops_za64[_u16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svuint16_t zn, svuint16_t zm);
 ```
 
 #### FMOPS (non-widening)
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za32[_f32](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svfloat32_t zn, svfloat32_t zm);
+  void svmops_za32[_f32]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svfloat32_t zn, svfloat32_t zm);
 
   // Only if __ARM_FEATURE_SME_F64F64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svmops_za64[_f64](uint64_t tile, svbool_t pn, svbool_t pm,
-                         svfloat64_t zn, svfloat64_t zm);
+  void svmops_za64[_f64]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                           svfloat64_t zn, svfloat64_t zm);
 ```
 
 #### RDSVL
@@ -9304,52 +9304,52 @@ possible to write these operations using normal C arithmetic. For example:
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svsumopa_za32[_s8](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svint8_t zn, svuint8_t zm);
+  void svsumopa_za32[_s8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svint8_t zn, svuint8_t zm);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svsumopa_za64[_s16](uint64_t tile, svbool_t pn, svbool_t pm,
-                           svint16_t zn, svuint16_t zm);
+  void svsumopa_za64[_s16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                             svint16_t zn, svuint16_t zm);
 ```
 
 #### SUMOPS
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svsumops_za32[_s8](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svint8_t zn, svuint8_t zm);
+  void svsumops_za32[_s8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svint8_t zn, svuint8_t zm);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svsumops_za64[_s16](uint64_t tile, svbool_t pn, svbool_t pm,
-                           svint16_t zn, svuint16_t zm);
+  void svsumops_za64[_s16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                             svint16_t zn, svuint16_t zm);
 ```
 
 #### USMOPA
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svusmopa_za32[_u8](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svuint8_t zn, svint8_t zm);
+  void svusmopa_za32[_u8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svuint8_t zn, svint8_t zm);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svusmopa_za64[_u16](uint64_t tile, svbool_t pn, svbool_t pm,
-                           svuint16_t zn, svint16_t zm);
+  void svusmopa_za64[_u16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                             svuint16_t zn, svint16_t zm);
 ```
 
 #### USMOPS
 
 ``` c
   __attribute__((arm_streaming, arm_shared_za))
-  void svusmops_za32[_u8](uint64_t tile, svbool_t pn, svbool_t pm,
-                          svuint8_t zn, svint8_t zm);
+  void svusmops_za32[_u8]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                            svuint8_t zn, svint8_t zm);
 
   // Only if __ARM_FEATURE_SME_I16I64 != 0
   __attribute__((arm_streaming, arm_shared_za))
-  void svusmops_za64[_u16](uint64_t tile, svbool_t pn, svbool_t pm,
-                           svuint16_t zn, svint16_t zm);
+  void svusmops_za64[_u16]_m(uint64_t tile, svbool_t pn, svbool_t pm,
+                             svuint16_t zn, svint16_t zm);
 ```
 
 #### ZERO


### PR DESCRIPTION
While implementing the SME ACLE for GCC, I noticed that svwrite was inconsistent with svadd* and with the MOP intrinsics.  svwrite (which maps to MOVA) had an _m suffix, to reflect the /M on the assembly predicate operands, but the other functions didn't.

We could resolve the inconsistency in either direction: remove _m from svwrite or add it to the other intrinsics. Although I don't have a strong preference, adding the _m to the other intrinsics seems more future proof.  SME2 adds various unpredicated intrinsics and there's a risk of a future name clash if we don't establish a distinction between /m functions and unpredicated functions.  Making _m explicit also seems more consistent with SVE.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](../CONTRIBUTING.md), in particular the section on [submitting
a proposal](../CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [x] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [x] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](../CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](../README.md#contributors-) page of the project.
