### PR TITLE
docs: use GitHub absolute links in PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: fpetrogalli
 
 ---
 
-<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 **Describe the bug**
@@ -26,4 +26,4 @@ We will work to solve the bug report in time for the upcoming
 release. However, we would like to encourage you to submit the fix
 yourself, if possible. If you intend to do so and this is your first
 contribution, we recommend reading our [contribution
-guidelines](../../CONTRIBUTING.md).
+guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -5,7 +5,7 @@ title: "[proposal]"
 
 ---
 
-<!-- SPDX-FileCopyrightText: Copyright 2021 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 **Thank you for submitting a proposal!**
@@ -14,5 +14,5 @@ We are looking forward to evaluate your proposal, and if possible to
 make it part of the Arm C Language Extension (ACLE) specifications.
 
 We would like to encourage you reading through the [contribution
-guidelines](../../CONTRIBUTING.md), in particular the section on [submitting
-a proposal](../../CONTRIBUTING.md#proposals-for-new-content).
+guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
+a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,8 +19,8 @@ We are looking forward to evaluate your proposal, and if possible to
 make it part of the Arm C Language Extension (ACLE) specifications.
 
 We would like to encourage you reading through the [contribution
-guidelines](../CONTRIBUTING.md), in particular the section on [submitting
-a proposal](../CONTRIBUTING.md#proposals-for-new-content).
+guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
+a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).
 
 Please use the proposal label.
 
@@ -45,7 +45,7 @@ Checklist: (mark with ``X`` those which apply)
 * [ ] I have run the CI scripts (if applicable, as they might be
       tricky to set up on non-*nix machines). The sequence can be
       found in the [contribution
-      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
+      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
       worry if you cannot run these scripts on your machine, your
       patch will be automatically checked in the Actions of the pull
       request.
@@ -59,8 +59,8 @@ Checklist: (mark with ``X`` those which apply)
 * [ ] When modifying content and/or its rendering, I have checked the
       correctness of the result in the PDF output (please refer to the
       instructions on [how to build the PDFs
-      locally](../CONTRIBUTING.md#continuous-integration)).
+      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
 * [ ] The variable `draftversion` is set to `true` in the YAML header
       of the sources of the specifications I have modified.
 * [ ] Please *DO NOT* add my GitHub profile to the list of contributors
-      in the [README](../README.md#contributors-) page of the project.
+      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.


### PR DESCRIPTION
GitHub does not work correctly with relative links in PR and issue templates. Because of this, wrong links are generated in Pull Requests and Issues (i.e. error 404).

As far as I could find, there is no other solution besides changing them to absolute links. This is unfortunate because we now link directly to GitHub pages, but it's better than showing error 404 to contributors.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](../CONTRIBUTING.md), in particular the section on [submitting
a proposal](../CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [X] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [X] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](../CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](../CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](../README.md#contributors-) page of the project.
