### PR TITLE
[main] Some minor corrections

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -299,8 +299,6 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   No functional change intended.
 * Reordered the sections in [Change history](#change-history) in
   chronological order.
-* Added [**Alpha**](#current-status-and-anticipated-changes)
-  [support for SME](#arm_sme.h).
 
 #### Changes between ACLE Q1 2022 and ACLE Q2 2022
 
@@ -314,7 +312,16 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Fixes for [Function Multi Versioning](#function-multi-versioning):
   * typo in `FEAT_DPB2`.
   * added `FEAT_LS64*`.
+
+#### Changes for the next release
+
+* Added [**Alpha**](#current-status-and-anticipated-changes)
+  [support for SME](#arm_sme.h).
 * Added feature detection macro `__ARM_FEATURE_RCPC` for RCpc (Release Consistent processor consistent) model at [RCpc](#rcpc).
+* Added two new valid values to the
+  [SVE feature macros](#scalable-vector-extension-sve):
+  * `__ARM_FEATURE_SVE_VECTOR_OPERATORS=2`
+  * `__ARM_FEATURE_SVE_PREDICATE_OPERATORS=2`
 
 ### References
 
@@ -1654,7 +1661,7 @@ SVE language extensions:
 > The availability of operators on sizeless types is independent of
 > `__ARM_FEATURE_SVE_BITS`.
 
-**`__ARM_FEATURE_SVE_PREDICATE_OPERATORS==1`**
+**`__ARM_FEATURE_SVE_PREDICATE_OPERATORS==N`**
 
 > `N >= 1` indicates that applying the `arm_sve_vector_bits` attribute to
 > `svbool_t` creates a type that supports basic built-in vector operations.
@@ -8967,7 +8974,8 @@ following it. --><span id="__arm_za_disable"></span>
 The intrinsics in this section have the following properties in common:
 
 *   Every argument named `tile`, `slice_offset` or `tile_mask` must
-    be an integer constant expression.
+    be an integer constant expression in the range of the underlying
+    instruction.
 
 *   ZA loads and stores do not use typed pointers, since there is
     no C or C++ type information associated with the contents of ZA.


### PR DESCRIPTION
This patch moves changes that have been made since the 2022Q2 release to a new changelog section.  It also fixes a typo/ missed change in __ARM_FEATURE_SVE_PREDICATE_OPERATORS and clarifies that SME immediate operands must be in the range of the underlying instructions.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [x] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [x] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [x] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
