### PR TITLE
[main] Combine SME slice parameters

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -9001,9 +9001,21 @@ following it. --><span id="__arm_za_disable"></span>
 
 The intrinsics in this section have the following properties in common:
 
-*   Every argument named `tile`, `slice_offset` or `tile_mask` must
-    be an integer constant expression in the range of the underlying
-    instruction.
+*   Every argument named `tile` or `tile_mask` must be an integer constant
+    expression in the range of the underlying instruction.
+
+*   Some SME instructions identify a slice of ZA using the sum of a 32-bit
+    general-purpose register and an immediate offset.  The intrinsics for
+    these instructions have a 32-bit argument called `slice`, which is
+    interpreted as follows:
+
+    *   If the intrinsic also has a `vnum` argument, the ZA slice number
+        is calculated by adding `vnum` to `slice`.  Both `slice` and `vnum`
+        can both be variable.
+
+    *   Otherwise, `slice` specifies the ZA slice number directly; that is,
+        it represents the sum of the 32-bit register and the immediate
+        offset.  `slice` can be variable.
 
 *   ZA loads and stores do not use typed pointers, since there is
     no C or C++ type information associated with the contents of ZA.
@@ -9017,36 +9029,42 @@ The intrinsics in this section have the following properties in common:
 ``` c
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za))
-  void svld1_hor_za8(uint64_t tile, uint32_t slice_base,
-                     uint64_t slice_offset, svbool_t pg, const void *ptr);
+  void svld1_hor_za8(uint64_t tile, uint32_t slice, svbool_t pg,
+                     const void *ptr);
 
-  // Synthetic intrinsic: adds vnum * svcntsb() to the address given by ptr.
+  // Synthetic intrinsic: adds vnum to slice and vnum * svcntsb() to the
+  // address given by ptr.
+  //
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za))
-  void svld1_hor_vnum_za8(uint64_t tile, uint32_t slice_base,
-                          uint64_t slice_offset, svbool_t pg,
+  void svld1_hor_vnum_za8(uint64_t tile, uint32_t slice, svbool_t pg,
                           const void *ptr, int64_t vnum);
 
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za))
-  void svld1_ver_za8(uint64_t tile, uint32_t slice_base,
-                     uint64_t slice_offset, svbool_t pg, const void *ptr);
+  void svld1_ver_za8(uint64_t tile, uint32_t slice, svbool_t pg,
+                     const void *ptr);
 
-  // Synthetic intrinsic: adds vnum * svcntsb() to the address given by ptr.
+  // Synthetic intrinsic: adds vnum to slice and vnum * svcntsb() to the
+  // address given by ptr.
+  //
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za))
-  void svld1_ver_vnum_za8(uint64_t tile, uint32_t slice_base,
-                          uint64_t slice_offset, svbool_t pg,
+  void svld1_ver_vnum_za8(uint64_t tile, uint32_t slice, svbool_t pg,
                           const void *ptr, int64_t vnum);
 ```
 
 #### LDR
 
 ``` c
-  // slice_offset fills the role of the usual vnum parameter.
   __attribute__((arm_streaming_compatible, arm_shared_za))
-  void svldr_vnum_za(uint32_t slice_base, uint64_t slice_offset,
-                     const void *ptr);
+  void svldr_za(uint32_t slice, const void *ptr);
+
+  // Adds vnum to slice and vnum * svcntsb() to the address given by ptr.
+  // This can be done in a single instruction if vnum is a constant in the
+  // range [0, 15].  The intrinsic is synthetic for other vnum parameters.
+  __attribute__((arm_streaming_compatible, arm_shared_za))
+  void svldr_vnum_za(uint32_t slice, const void *ptr, int64_t vnum);
 ```
 
 #### ST1B, ST1H, ST1W, ST1D, ST1Q
@@ -9054,37 +9072,42 @@ The intrinsics in this section have the following properties in common:
 ``` c
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
-  void svst1_hor_za8(uint64_t tile, uint32_t slice_base,
-                     uint64_t slice_offset, svbool_t pg,
+  void svst1_hor_za8(uint64_t tile, uint32_t slice, svbool_t pg,
                      void *ptr);
 
-  // Synthetic intrinsic: adds vnum * svcntsb() to the address given by ptr.
+  // Synthetic intrinsic: adds vnum to slice and vnum * svcntsb() to the
+  // address given by ptr.
+  //
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
-  void svst1_hor_vnum_za8(uint64_t tile, uint32_t slice_base,
-                          uint64_t slice_offset, svbool_t pg,
+  void svst1_hor_vnum_za8(uint64_t tile, uint32_t slice, svbool_t pg,
                           void *ptr, int64_t vnum);
 
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
-  void svst1_ver_za8(uint64_t tile, uint32_t slice_base,
-                     uint64_t slice_offset, svbool_t pg,
+  void svst1_ver_za8(uint64_t tile, uint32_t slice, svbool_t pg,
                      void *ptr);
 
-  // Synthetic intrinsic: adds vnum * svcntsb() to the address given by ptr.
+  // Synthetic intrinsic: adds vnum to slice and vnum * svcntsb() to the
+  // address given by ptr.
+  //
   // Also for _za16, _za32, _za64 and _za128 (with the same prototype).
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
-  void svst1_ver_vnum_za8(uint64_t tile, uint32_t slice_base,
-                          uint64_t slice_offset, svbool_t pg,
+  void svst1_ver_vnum_za8(uint64_t tile, uint32_t slice, svbool_t pg,
                           void *ptr, int64_t vnum);
 ```
 
 #### STR
 
 ``` c
-  // slice_offset fills the role of the usual vnum parameter.
   __attribute__((arm_streaming_compatible, arm_shared_za, arm_preserves_za))
-  void svstr_vnum_za(uint32_t slice_base, uint64_t slice_offset, void *ptr);
+  void svstr_za(uint32_t slice, void *ptr);
+
+  // Adds vnum to slice and vnum * svcntsb() to the address given by ptr.
+  // This can be done in a single instruction if vnum is a constant in the
+  // range [0, 15].  The intrinsic is synthetic for other vnum parameters.
+  __attribute__((arm_streaming_compatible, arm_shared_za, arm_preserves_za))
+  void svstr_vnum_za(uint32_t slice, void *ptr, int64_t vnum);
 ```
 
 #### MOVA
@@ -9098,32 +9121,27 @@ parameter both have type `svuint8_t`.
   // And similarly for u8.
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
   svint8_t svread_hor_za8[_s8]_m(svint8_t zd, svbool_t pg,
-                                 uint64_t tile, uint32_t slice_base,
-                                 uint64_t slice_offset);
+                                 uint64_t tile, uint32_t slice);
 
   // And similarly for u16, bf16 and f16.
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
   svint16_t svread_hor_za16[_s16]_m(svint16_t zd, svbool_t pg,
-                                    uint64_t tile, uint32_t slice_base,
-                                    uint64_t slice_offset);
+                                    uint64_t tile, uint32_t slice);
 
   // And similarly for u32 and f32.
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
   svint32_t svread_hor_za32[_s32]_m(svint32_t zd, svbool_t pg,
-                                    uint64_t tile, uint32_t slice_base,
-                                    uint64_t slice_offset);
+                                    uint64_t tile, uint32_t slice);
 
   // And similarly for u64 and f64.
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
   svint64_t svread_hor_za64[_s64]_m(svint64_t zd, svbool_t pg,
-                                    uint64_t tile, uint32_t slice_base,
-                                    uint64_t slice_offset);
+                                    uint64_t tile, uint32_t slice);
 
   // And similarly for s16, s32, s64, u8, u16, u32, u64, bf16, f16, f32, f64
   __attribute__((arm_streaming, arm_shared_za, arm_preserves_za))
   svint8_t svread_hor_za128[_s8]_m(svint8_t zd, svbool_t pg,
-                                   uint64_t tile, uint32_t slice_base,
-                                   uint64_t slice_offset);
+                                   uint64_t tile, uint32_t slice);
 ```
 
 Replacing `_hor` with `_ver` gives the associated vertical forms.
@@ -9135,32 +9153,27 @@ the `zn` parameter to the `_u8` intrinsic has type `svuint8_t`.
 ``` c
   // And similarly for u8.
   __attribute__((arm_streaming, arm_shared_za))
-  void svwrite_hor_za8[_s8]_m(uint64_t tile, uint32_t slice_base,
-                              uint64_t slice_offset, svbool_t pg,
+  void svwrite_hor_za8[_s8]_m(uint64_t tile, uint32_t slice, svbool_t pg,
                               svint8_t zn);
 
   // And similarly for u16, bf16 and f16.
   __attribute__((arm_streaming, arm_shared_za))
-  void svwrite_hor_za16[_s16]_m(uint64_t tile, uint32_t slice_base,
-                                uint64_t slice_offset, svbool_t pg,
+  void svwrite_hor_za16[_s16]_m(uint64_t tile, uint32_t slice, svbool_t pg,
                                 svint16_t zn);
 
   // And similarly for u32 and f32.
   __attribute__((arm_streaming, arm_shared_za))
-  void svwrite_hor_za32[_s32]_m(uint64_t tile, uint32_t slice_base,
-                                uint64_t slice_offset, svbool_t pg,
+  void svwrite_hor_za32[_s32]_m(uint64_t tile, uint32_t slice, svbool_t pg,
                                 svint32_t zn);
 
   // And similarly for u64 and f64.
   __attribute__((arm_streaming, arm_shared_za))
-  void svwrite_hor_za64[_s64]_m(uint64_t tile, uint32_t slice_base,
-                                uint64_t slice_offset, svbool_t pg,
+  void svwrite_hor_za64[_s64]_m(uint64_t tile, uint32_t slice, svbool_t pg,
                                 svint64_t zn);
 
   // And similarly for s16, s32, s64, u8, u16, u32, u64, bf16, f16, f32, f64
   __attribute__((arm_streaming, arm_shared_za))
-  void svwrite_hor_za128[_s8]_m(uint64_t tile, uint32_t slice_base,
-                                uint64_t slice_offset, svbool_t pg,
+  void svwrite_hor_za128[_s8]_m(uint64_t tile, uint32_t slice, svbool_t pg,
                                 svint8_t zn);
 ```
 


### PR DESCRIPTION
Previously the (alpha) SME intrinsics were documented to take two slice parameters: a 32-bit variable index and a 64-bit constant offset.  However, it isn't very C-like to split an addition in this way, and as Sander points out, it isn't really consistent with the way that we handle vnum parameters.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
