### PR TITLE
Add SLC as a valid Prefetch Target

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -326,6 +326,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   * Added missing features of `ID_AA64ISAR1_EL1` and `ID_AA64ISAR2_EL1`.
   * Renamed the feature macro to `__HAVE_FUNCTION_MULTI_VERSIONING`
   * Added some clarifications.
+* Adds SLC as a valid Cache Level for the Memory prefetch intrinsics.
 
 ### References
 
@@ -2996,11 +2997,12 @@ values.
 | PLD             | 0         | Fetch the addressed location for reading |
 | PST             | 1         | Fetch the addressed location for writing |
 
-| Cache Level | Value | Summary                                  |
-| ----------- | ----- | ---------------------------------------- |
-| L1          | 0     | Fetch the addressed location to L1 cache |
-| L2          | 1     | Fetch the addressed location to L2 cache |
-| L3          | 2     | Fetch the addressed location to L3 cache |
+| Cache Level | Value | Summary                                                |
+| ----------- | ----- | ------------------------------------------------------ |
+| L1          | 0     | Fetch the addressed location to L1 cache               |
+| L2          | 1     | Fetch the addressed location to L2 cache               |
+| L3          | 2     | Fetch the addressed location to L3 cache               |
+| SLC         | 3     | Fetch the addressed location to the System-Level Cache |
 
 | **Retention Policy** | **Value** | **Summary**                                                                |
 | -------------------- | --------- | -------------------------------------------------------------------------- |


### PR DESCRIPTION
Arm v8.9-a/v9.4-a has allocated the encoding 0b11 in PRFM's `Rt<2:1>` field (which represents the cache level targetted by the prefetch instruction) the name "SLC", to represent prefetches to the system-level cache. In some documents this is called FEAT_PRFMSLC.

This change updates the ACLE intrinsics to match what is available in the PRFM instructions.

---

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [X] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
