### PR TITLE
Clarify licensing information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ title: Contribution Guidelines
 ---
 <!-- SPDX-FileCopyrightText: Copyright 2021-2023 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- See LICENSE.md file for details -->
 
 # Thank you for considering contributing!
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,11 +6,11 @@
 All the open-source ACLE documents are not dependent on any assets
 outside of their own directory and all have their own license file
 included in the directory. Currently all the open-source ACLE documents
-are licenced under the **Creative Commons Attribution-ShareAlike 4.0
+are licensed under the **Creative Commons Attribution-ShareAlike 4.0
 International License + grant of Patent License**. Contributions to
 the specifications are accepted under the same license.
 
-This licence is applied to the content of the following folders and
+This license is applied to the content of the following folders and
 relative subfolders:
 
 * [main](main)
@@ -27,8 +27,9 @@ themselves, so for more information consult the individual documents.
 
 # License for the rest of the project
 
-All the remaining content not listed in the [previous
-section](#license-for-the-specifications) is covered by the Apache 2.0
-license. [A copy of the license is provided in the `tools`
-folder](tools/LICENSE). Contributions for this content is accepted
-under the same license.
+All the remaining content not listed in the previous sections is covered by
+the Apache 2.0 license, with the exception of one file in the
+[`tools`](tools) folder that is licensed under the BSD 3-Clause license.
+[A copy of these licenses is provided in the `tools`
+folder](tools/LICENSE.md). Contributions for this content is accepted under
+the same license.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ of Patent License.
 The closed-source [legacy ACLE releases](legacyreleases/README.md) are
 licensed under an Arm proprietary license.
 
-The files in the subdirectories of the `tools` directory are provided
-under the Apache 2.0 license.
-
 For more information see [LICENSE](LICENSE.md).
 
 ## Past contributors

--- a/tools/LICENSE.md
+++ b/tools/LICENSE.md
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+## Apache License Version 2.0
 
                                  Apache License
                            Version 2.0, January 2004
@@ -200,3 +204,34 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+## BSD 3-Clause "New" or "Revised" License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    (1) Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    (2) Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    (3)The name of the author may not be used to
+    endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/tools/acle_template.tex
+++ b/tools/acle_template.tex
@@ -1,7 +1,7 @@
 % Copyright (c) 2014--2021, John MacFarlane
 % SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+% SPDX-License-Identifier: BSD-3-Clause
 % Based on default.latex template released with Pandoc (www.pandoc.org).
-% License: BSD 3-clause
 % See `data/templates` in `COPYRIGHT` at https://github.com/jgm/pandoc
 
 \documentclass[a4,10pt]{report}


### PR DESCRIPTION
One of the files under the tools directory is under the BSD 3-Clause license, but this fact is not clear in our licensing descriptions. This has been fixed.

Additionally, a copy of the BSD 3-Clause is included in the project in order to abide by its requirements.

This patch also fixes some related typos and changes all instances of "licence" to the US English spelling.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [x] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
