### PR TITLE
Remove incorrect optimisation remark in CMSE's floating-point register clearing

### DIFF
--- a/cmse/cmse.md
+++ b/cmse/cmse.md
@@ -12,7 +12,7 @@ toc: true
 ---
 
 <!--
-SPDX-FileCopyrightText: Copyright 2019, 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+SPDX-FileCopyrightText: Copyright 2019, 2021-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 CC-BY-SA-4.0 AND Apache-Patent-License
 See LICENSE.md file for details
 -->
@@ -115,7 +115,7 @@ about Arm’s trademarks.
 
 ## Copyright
 
-Copyright 2019, 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
+Copyright 2019, 2021-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>.
 
 # ABOUT THIS DOCUMENT
 
@@ -153,6 +153,11 @@ Anticipated changes to this document include:
   stack frame of a non-secure function call](#figure6) from `struct s
   NS nsfunc(struct s);` to `struct s NS (*nsfunc)(struct
   s);`. Non-secure functions have to be function pointers.
+
+#### Changes for next release
+
+* Removed incorrect optimisation remark in section
+  [Arguments on the stack and floating point handling](#arguments-on-the-stack-and-floating-point-handling).
 
 ## References
 
@@ -1837,11 +1842,6 @@ __acle_se_foo:
     @19: return to non-secure state
     bxns    lr
 ```  
-  
-The instruction sequence between comment 14 and 15 is an optimization to skip
-clearing floating point registers if they are not used by the secure state.
-Removing these instructions is functionally equivalent but might create an
-unnecessary floating point context.
 
 ### Return value on the stack
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -339,7 +339,8 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Fixes for [Function Multi Versioning](#function-multi-versioning):
   * Renamed features to `sme-f64f64` and `sme-i16i64`
   * Corrected register name to `ID_AA64SMFR0_EL1.I16I64`
-
+* Removed incorrect optimisation remark in [CMSE](#CMSE-ACLE)'s floating-point
+  register clearing.
 
 ### References
 


### PR DESCRIPTION
The section "Arguments on the stack and floating point handling" contains an incorrect remark about its example code sequence.

It states that clearing FP registers only if they contain Secure information is an optimisation in the sense that it can be done regardless. This is wrong since the clearing must not be done if they don't have Secure information. Otherwise an unnecessary FP context would be created, which could have serious side effects such as the raise of UsageFault.

This patch removes the incorrect text.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [x] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [x] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [x] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [x] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
