### PR TITLE
Remove incorrect information about the floating-point ABI used in CMSE's Arguments on the stack and floating point handling

### DIFF
--- a/cmse/cmse.md
+++ b/cmse/cmse.md
@@ -158,6 +158,8 @@ Anticipated changes to this document include:
 
 * Removed incorrect optimisation remark in section
   [Arguments on the stack and floating point handling](#arguments-on-the-stack-and-floating-point-handling).
+* Removed incorrect information about the floating-point ABI used in
+  [Arguments on the stack and floating point handling](#arguments-on-the-stack-and-floating-point-handling).
 
 ## References
 
@@ -1769,8 +1771,7 @@ The function `foo()` uses the stack to pass the last two arguments. It is
 unknown if the function `bar()` uses floating point registers to store secret
 information.
 
-The following T32 instruction sequence is an implementation of this function
-using the soft-float ABI:
+The following T32 instruction sequence is an implementation of this function:
 
 ``` c
 .global foo
@@ -1823,7 +1824,7 @@ __acle_se_foo:
     mrs     r1, control
     tst     r1, #8
     bne     .LdoneFP
-    @15: clear floating point caller-saved registers (soft ABI)
+    @15: clear floating point caller-saved registers
     mov     r1, #0
     vmov    s0, s1, r1, r1
     vmov    s2, s3, r1, r1

--- a/main/acle.md
+++ b/main/acle.md
@@ -341,6 +341,8 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   * Corrected register name to `ID_AA64SMFR0_EL1.I16I64`
 * Removed incorrect optimisation remark in [CMSE](#CMSE-ACLE)'s floating-point
   register clearing.
+* Removed incorrect information about the floating-point ABI used in
+  [CMSE](#CMSE-ACLE)'s Arguments on the stack and floating point handling.
 
 ### References
 


### PR DESCRIPTION
In CMSE section 8.4.2, the example states that some code sequence that clears FP registers is relevant due to the "soft float ABI".  This is wrong because FP registers aren't available in the soft float ABI to begin with.

This patch removes the mention to soft float ABI.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [x] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [x] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
