### PR TITLE
Describe reinterpret intrinsics for vector and vector tuple types

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -359,6 +359,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Changed the [SME language extensions](#sme-language-extensions-and-intrinsics)
   to use keyword attributes instead of GNU-style attributes.
 * Added missing word to Function Multi Versioning's [Name mangling](#name-mangling).
+* Added description of SVE reinterpret intrinsics.
 
 ### References
 
@@ -5927,18 +5928,6 @@ definition of `bfloat16_t` (see [Scalar types defined by
 `<arm_sve.h>`](#scalar-types-defined-by-arm_sve.h)). The other
 types are available unconditionally.
 
-ACLE provides two sets of intrinsics for converting between vector types:
-
-*   The [`svreinterpret`](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svreinterpret)
-    intrinsics simply reinterpret a vector of one type as a vector of another
-    type, without changing any of the bits.
-
-*   The [`svcvt`](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svcvt_)
-    intrinsics instead perform numerical conversion from one type to another,
-    such as converting integers to floating-point values.
-
-To avoid any ambiguity between the two operations, ACLE does not allow
-C-style casting from one vector type to another.
 
 [`<arm_sve.h>`](#arm_sve.h) also defines tuples of two, three, and four
 vectors, as follows:
@@ -5997,6 +5986,20 @@ vectors using [`svundef`](https://developer.arm.com/architectures/instruction-se
 [`svundef2`](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svundef2),
 [`svundef3`](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svundef3) and
 [`svundef4`](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svundef4).
+
+ACLE provides two sets of intrinsics for converting between vector types
+and between vector tuple types:
+
+*   The [`svreinterpret`](#sve-reinterpret-intrinsics) intrinsics simply
+    reinterpret a vector (or vector tuple) of one type as a vector (or
+    vector tuple) of another type, without changing any of the bits.
+
+*   The [`svcvt`](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svcvt_)
+    intrinsics instead perform numerical conversion from one type to another,
+    such as converting integers to floating-point values.
+
+To avoid any ambiguity between the two operations, ACLE does not allow
+C-style casting from one vector type to another.
 
 ### SVE predicate types
 
@@ -7156,9 +7159,29 @@ Assuming `float64_t` data, the C version of the code above would be:
   p3 = svrdffr();
 ```
 
+### SVE reinterpret intrinsics
+
+The `svreinterpret` intrinsics for vector types and vector tuple types take the form
+
+``` c
+svreinterpret_type0[_type1_xN]
+```
+
+where `N` refers to the number of elements in a tuple type (2, 3, or 4).
+
+For example:
+``` c
+svuin16_t svreinterpret_u16_s32(svint32_t op);
+svuin16_t svreinterpret_u16(svint32_t op);
+svuin16x2_t svreinterpret_u16_s32_x2(svint32x2_t op);
+svuin16x2_t svreinterpret_u16(svint32x2_t op);
+```
+
+A list of SVE reinterpret intrinsics can be found on [developer.arm.com](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=svreinterpret).
+
 ### List of SVE intrinsics
 
-The full list of SVE intrinsics can be found on
+The list of SVE intrinsics can be found on
 [developer.arm.com](https://developer.arm.com/architectures/instruction-sets/intrinsics/#f:@navigationhierarchiessimdisa=[sve,sve2]).
 This list includes SVE2 and other SVE extensions (such as the 32-bit
 matrix multiply extensions).


### PR DESCRIPTION
Change-Id: Iba0e37d8b12debe34edae3bb8350bb1ef80a616a

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [X] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [X] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [X] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [x] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [X] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
