### PR TITLE
[FMV] Change the default versions name mangling.

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -2490,8 +2490,9 @@ compiler and it is enabled.
 
 ### Name mangling
 
-The `"default"` version is not mangled on top of the language-specific name
-mangling.
+The `"default"` version is mangled with `".default"` on top of the
+language-specific name mangling. When the `"default"` version matches with an
+explicitly provided version an alias to be generated.
 
 The mangling function is compatible with the mangling for version information of
 the [[cxxabi]](#cxxabi), and it is defined as follows:
@@ -2510,7 +2511,7 @@ For example:
 __attribute__((target_clones("crc32", "aes+sha1")))
 int foo(){..}
 ```
-will produce these mangled names for C language: `foo`, `foo._Mcrc32`,
+will produce these mangled names for C language: `foo.default`, `foo._Mcrc32`,
 `foo._Msha1Maes`.
 
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -2493,8 +2493,8 @@ compiler and it is enabled.
 
 The `"default"` version is mangled with `".default"` on top of the
 language-specific name mangling.
-language-specific name mangling. When the `"default"` version matches with an
-explicitly provided version an alias to be generated.
+All versioned functions with their mangled name are always resolvable.
+A function is expected to be resolvable with the original mangled name of the function.
 
 The mangling function is compatible with the mangling for version information of
 the [[cxxabi]](#cxxabi), and it is defined as follows:
@@ -2514,7 +2514,8 @@ __attribute__((target_clones("crc32", "aes+sha1")))
 int foo(){..}
 ```
 will produce these mangled names for C language: `foo.default`, `foo._Mcrc32`,
-`foo._Msha1Maes`.
+`foo._Msha1Maes` while `foo` is a callable external symbol which leads to one
+of the versioned function.
 
 
 ### Mapping

--- a/main/acle.md
+++ b/main/acle.md
@@ -2492,8 +2492,8 @@ compiler and it is enabled.
 ### Name mangling
 
 The `"default"` version is mangled with `".default"` on top of the
-language-specific name mangling.
-All versioned functions with their mangled name are always resolvable.
+language-specific name mangling. All versioned functions with their mangled names
+are always resolvable.
 A function is expected to be resolvable with the original mangled name of the function.
 
 The mangling function is compatible with the mangling for version information of
@@ -2515,7 +2515,7 @@ int foo(){..}
 ```
 will produce these mangled names for C language: `foo.default`, `foo._Mcrc32`,
 `foo._Msha1Maes` while `foo` is a callable external symbol which leads to one
-of the versioned function.
+of the versioned functions.
 
 
 ### Mapping

--- a/main/acle.md
+++ b/main/acle.md
@@ -362,6 +362,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added description of SVE reinterpret intrinsics.
 * Changes and fixes for [Function Multi Versioning](#function-multi-versioning):
   * Added [MOPS](#memcpy-family-of-operations-intrinsics---mops).
+  * Change name mangling of the default version.
   * Align priorities to account for feature dependencies.
   * Introduce alternative names (aliases) `rdma` for `rdm`.
 * Introduced the `__ARM_FEATURE_PAUTH_LR` feature macro in section
@@ -2491,6 +2492,7 @@ compiler and it is enabled.
 ### Name mangling
 
 The `"default"` version is mangled with `".default"` on top of the
+language-specific name mangling.
 language-specific name mangling. When the `"default"` version matches with an
 explicitly provided version an alias to be generated.
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

The default version's name to be mangled to avoid problems with ifuncs due to the ifunc to be called as the base name of the function.


As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [x] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [x] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
