### PR TITLE
Tweaks to the SME2 intrinsics

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -9279,7 +9279,7 @@ ZA array vectors. The intrinsics model this in the following way:
 
 ``` c
     // Reads 2 consecutive horizontal tile slices from ZA into multi-vector.
-    svint8x2_t svread_hor_za8[_s8]_vg2(uint64_t tile, uint32_t slice)
+    svint8x2_t svread_hor_za8_s8_vg2(uint64_t tile, uint32_t slice)
       __arm_streaming __arm_shared_za __arm_preserves_za;
 ```
 
@@ -11225,42 +11225,43 @@ Zero ZT0
 Lookup table read with 2-bit and 4-bit indexes
 
 ``` c
-  // Variants are also available for _zt[_s8], _zt[_u16], _zt[_s16], _zt[_u32]
-  // and _zt[_s32]
-  svuint8_t svluti2_lane_zt[_u8](uint64_t zt, svuint8_t zn, uint64_t imm_idx)
+  // Variants are also available for _zt_u8, _zt_s16, _zt_u16, _zt_f16,
+  // _zt_bf16, _zt_s32, _zt_u32 and _zt_f32
+  svint8_t svluti2_lane_zt_s8(uint64_t zt, svuint8_t zn, uint64_t imm_idx)
     __arm_streaming __arm_shared_za __arm_preserves_za;
 
 
-  // Variants are also available for _zt[_s8], _zt[_u16], _zt[_s16], _zt[_u32]
-  // and _zt[_s32]
-  svuint8x2_t svluti2_lane_zt[_u8]_x2(uint64_t zt, svuint8_t zn,
-                                      uint64_t imm_idx)
+  // Variants are also available for _zt_u8, _zt_s16, _zt_u16, _zt_f16,
+  // _zt_bf16, _zt_s32, _zt_u32 and _zt_f32
+  svint8x2_t svluti2_lane_zt_s8_x2(uint64_t zt, svuint8_t zn,
+                                   uint64_t imm_idx)
     __arm_streaming __arm_shared_za __arm_preserves_za;
 
 
-  // Variants are also available for _zt[_s8], _zt[_u16], _zt[_s16], _zt[_u32]
-  // and _zt[_s32]
-  svuint8x4_t svluti2_lane_zt[_u8]_x4(uint64_t zt, svuint8_t zn,
-                                      uint64_t imm_idx)
+  // Variants are also available for _zt_u8, _zt_s16, _zt_u16, _zt_f16,
+  // _zt_bf16, _zt_s32, _zt_u32 and _zt_f32
+  svint8x4_t svluti2_lane_zt_s8_x4(uint64_t zt, svuint8_t zn,
+                                   uint64_t imm_idx)
     __arm_streaming __arm_shared_za __arm_preserves_za;
 
 
-  // Variants are also available for _zt[_s8], _zt[_u16], _zt[_s16], _zt[_u32]
-  // and _zt[_s32]
-  svuint8_t svluti4_lane_zt[_u8](uint64_t zt, svuint8_t zn, uint64_t imm_idx)
+  // Variants are also available for _zt_u8, _zt_s16, _zt_u16, _zt_f16,
+  // _zt_bf16, _zt_s32, _zt_u32 and _zt_f32
+  svint8_t svluti4_lane_zt_s8(uint64_t zt, svuint8_t zn, uint64_t imm_idx)
     __arm_streaming __arm_shared_za __arm_preserves_za;
 
 
-  // Variants are also available for _zt[_s8], _zt[_u16], _zt[_s16], _zt[_u32]
-  // and _zt[_s32]
-  svuint8x2_t svluti4_lane_zt[_u8]_x2(uint64_t zt, svuint8_t zn,
-                                      uint64_t imm_idx)
+  // Variants are also available for _zt_u8, _zt_s16, _zt_u16, _zt_f16,
+  // _zt_bf16, _zt_s32, _zt_u32 and _zt_f32
+  svint8x2_t svluti4_lane_zt_s8_x2(uint64_t zt, svuint8_t zn,
+                                   uint64_t imm_idx)
     __arm_streaming __arm_shared_za __arm_preserves_za;
 
 
-  // Variants are also available for _zt[_s16], _zt[_u32] and _zt[_s32]
-  svuint16x4_t svluti4_lane_zt[_u16]_x4(uint64_t zt, svuint16_t zn,
-                                        uint64_t imm_idx)
+  // Variants are also available for _zt_u16, _zt_f16, _zt_bf16, _zt_s32,
+  // _zt_u32 and _zt_f32
+  svint16x4_t svluti4_lane_zt_s16_x4(uint64_t zt, svuint16_t zn,
+                                     uint64_t imm_idx)
     __arm_streaming __arm_shared_za __arm_preserves_za;
   ```
 
@@ -11269,79 +11270,87 @@ Lookup table read with 2-bit and 4-bit indexes
 Move multi-vectors to/from ZA
 
 ``` c
-  // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
-  // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
-  svint8x2_t svread_hor_za8[_s8]_vg2(uint64_t tile, uint32_t slice)
+  // Variants are also available for _za8_u8, _za16_s16, _za16_u16,
+  // _za16_f16, _za16_bf16, _za32_s32, _za32_u32, _za32_f32,
+  // _za64_s64, _za64_u64 and _za64_f64
+  svint8x2_t svread_hor_za8_s8_vg2(uint64_t tile, uint32_t slice)
+    __arm_streaming __arm_shared_za __arm_preserves_za;
+
+
+  // Variants are also available for _za8_u8, _za16_s16, _za16_u16,
+  // _za16_f16, _za16_bf16, _za32_s32, _za32_u32, _za32_f32,
+  // _za64_s64, _za64_u64 and _za64_f64
+  svint8x4_t svread_hor_za8_s8_vg4(uint64_t tile, uint32_t slice)
+    __arm_streaming __arm_shared_za __arm_preserves_za;
+
+
+  // Variants are also available for _za8_u8, _za16_s16, _za16_u16,
+  // _za16_f16, _za16_bf16, _za32_s32, _za32_u32, _za32_f32,
+  // _za64_s64, _za64_u64 and _za64_f64
+  svint8x2_t svread_ver_za8_s8_vg2(uint64_t tile, uint32_t slice)
+    __arm_streaming __arm_shared_za __arm_preserves_za;
+
+
+  // Variants are also available for _za8_u8, _za16_s16, _za16_u16,
+  // _za16_f16, _za16_bf16, _za32_s32, _za32_u32, _za32_f32,
+  // _za64_s64, _za64_u64 and _za64_f64
+  svint8x4_t svread_ver_za8_s8_vg4(uint64_t tile, uint32_t slice)
+    __arm_streaming __arm_shared_za __arm_preserves_za;
+
+
+  // Variants are also available for _za8_u8, _za16_s16, _za16_u16,
+  // _za16_f16, _za16_bf16, _za32_s32, _za32_u32, _za32_f32,
+  // _za64_s64, _za64_u64 and _za64_f64
+  svint8x2_t svread_za8_s8_vg1x2(uint32_t slice)
+    __arm_streaming __arm_shared_za __arm_preserves_za;
+
+
+  // Variants are also available for _za8_u8, _za16_s16, _za16_u16,
+  // _za16_f16, _za16_bf16, _za32_s32, _za32_u32, _za32_f32,
+  // _za64_s64, _za64_u64 and _za64_f64
+  svint8x4_t svread_za8_s8_vg1x4(uint32_t slice)
     __arm_streaming __arm_shared_za __arm_preserves_za;
 
 
   // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
   // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
-  svint8x4_t svread_hor_za8[_s8]_vg4(uint64_t tile, uint32_t slice)
-    __arm_streaming __arm_shared_za __arm_preserves_za;
-
-
-  // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
-  // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
-  svint8x2_t svread_ver_za8[_s8]_vg2(uint64_t tile, uint32_t slice)
-    __arm_streaming __arm_shared_za __arm_preserves_za;
-
-
-  // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
-  // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
-  svint8x4_t svread_ver_za8[_s8]_vg4(uint64_t tile, uint32_t slice)
-    __arm_streaming __arm_shared_za __arm_preserves_za;
-
-
-  // Variants are also available for _za64_u64 and _za64_f64
-  svint64x2_t svread_za64_s64_vg1x2(uint32_t slice)
-    __arm_streaming __arm_shared_za __arm_preserves_za;
-
-
-  // Variants are also available for _za64_u64 and _za64_f64
-  svint64x4_t svread_za64_s64_vg1x4(uint32_t slice)
-    __arm_streaming __arm_shared_za __arm_preserves_za;
-
-
-  // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
-  // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
+  // _za64[_s64], _za64[_u64] and _za64[_f64]
   void svwrite_hor_za8[_s8]_vg2(uint64_t tile, uint32_t slice, svint8x2_t zn)
     __arm_streaming __arm_shared_za;
 
 
   // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
   // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
+  // _za64[_s64], _za64[_u64] and _za64[_f64]
   void svwrite_hor_za8[_s8]_vg4(uint64_t tile, uint32_t slice, svint8x4_t zn)
     __arm_streaming __arm_shared_za;
 
 
   // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
   // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
+  // _za64[_s64], _za64[_u64] and _za64[_f64]
   void svwrite_ver_za8[_s8]_vg2(uint64_t tile, uint32_t slice, svint8x2_t zn)
     __arm_streaming __arm_shared_za;
 
 
   // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
   // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
-  // _za64[_s64], _za64[_u64] and _za64_[f64]
+  // _za64[_s64], _za64[_u64] and _za64[_f64]
   void svwrite_ver_za8[_s8]_vg4(uint64_t tile, uint32_t slice, svint8x4_t zn)
     __arm_streaming __arm_shared_za;
 
 
-  // Variants are also available for _za64[_u64] and _za64[_f64]
-  void svwrite_za64[_s64]_vg1x2(uint32_t slice, svint64x2_t zn)
+  // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
+  // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
+  // _za64[_s64], _za64[_u64] and _za64[_f64]
+  void svwrite_za8[_s8]_vg1x2(uint32_t slice, svint8x2_t zn)
     __arm_streaming __arm_shared_za;
 
 
-  // Variants are also available for _za64[_u64] and _za64[_f64]
-  void svwrite_za64[_s64]_vg1x4(uint32_t slice, svint64x4_t zn)
+  // Variants are also available for _za8[_u8], _za16[_s16], _za16[_u16],
+  // _za16[_f16], _za16[_bf16], _za32[_s32], _za32[_u32], _za32[_f32],
+  // _za64[_s64], _za64[_u64] and _za64[_f64]
+  void svwrite_za8[_s8]_vg1x4(uint32_t slice, svint8x4_t zn)
     __arm_streaming __arm_shared_za;
   ```
 
@@ -11473,15 +11482,18 @@ Multi-vector saturating rounding shift right narrow
 
 ``` c
   // Variants are also available for _u8[_u32_x4]
-  svint8_t svqrshr_s8[_s32_x4](svint32x4_t zn, uint64_t imm) __arm_streaming;
+  svint8_t svqrshr[_n]_s8[_s32_x4](svint32x4_t zn, uint64_t imm)
+    __arm_streaming;
 
 
   // Variants are also available for _u16[_u32_x2]
-  svint16_t svqrshr_s16[_s32_x2](svint32x2_t zn, uint64_t imm) __arm_streaming;
+  svint16_t svqrshr[_n]_s16[_s32_x2](svint32x2_t zn, uint64_t imm)
+    __arm_streaming;
 
 
   // Variants are also available for _u16[_u64_x4]
-  svint16_t svqrshr_s16[_s64_x4](svint64x4_t zn, uint64_t imm) __arm_streaming;
+  svint16_t svqrshr[_n]_s16[_s64_x4](svint64x4_t zn, uint64_t imm)
+    __arm_streaming;
   ```
 
 #### SQRSHRN, UQRSHRN
@@ -11490,17 +11502,17 @@ Multi-vector saturating rounding shift right narrow and interleave
 
 ``` c
   // Variants are also available for _u8[_u32_x4]
-  svint8_t svqrshrn_s8[_s32_x4](svint32x4_t zn, uint64_t imm)
+  svint8_t svqrshrn[_n]_s8[_s32_x4](svint32x4_t zn, uint64_t imm)
     __arm_streaming;
 
 
   // Variants are also available for _u16[_u32_x2]
-  svint16_t svqrshrn_s16[_s32_x2](svint32x2_t zn, uint64_t imm)
+  svint16_t svqrshrn[_n]_s16[_s32_x2](svint32x2_t zn, uint64_t imm)
     __arm_streaming_compatible;
 
 
   // Variants are also available for _u16[_u64_x4]
-  svint16_t svqrshrn_s16[_s64_x4](svint64x4_t zn, uint64_t imm)
+  svint16_t svqrshrn[_n]_s16[_s64_x4](svint64x4_t zn, uint64_t imm)
     __arm_streaming;
   ```
 
@@ -11509,13 +11521,16 @@ Multi-vector saturating rounding shift right narrow and interleave
 Multi-vector saturating rounding shift right unsigned narrow
 
 ``` c
-  svuint8_t svqrshru_u8[_s32_x4](svint32x4_t zn, uint64_t imm) __arm_streaming;
+  svuint8_t svqrshru[_n]_u8[_s32_x4](svint32x4_t zn, uint64_t imm)
+    __arm_streaming;
 
 
-  svuint16_t svqrshru_u16[_s32_x2](svint32x2_t zn, uint64_t imm) __arm_streaming;
+  svuint16_t svqrshru[_n]_u16[_s32_x2](svint32x2_t zn, uint64_t imm)
+    __arm_streaming;
 
 
-  svuint16_t svqrshru_u16[_s64_x4](svint64x4_t zn, uint64_t imm) __arm_streaming;
+  svuint16_t svqrshru[_n]_u16[_s64_x4](svint64x4_t zn, uint64_t imm)
+    __arm_streaming;
   ```
 
 #### SQRSHRUN
@@ -11523,12 +11538,12 @@ Multi-vector saturating rounding shift right unsigned narrow
 Multi-vector saturating rounding shift right unsigned narrow and interleave
 
 ``` c
-  svuint16_t svqrshrun_u16[_s32_x2](svint32x2_t zn, uint64_t imm)
+  svuint16_t svqrshrun[_n]_u16[_s32_x2](svint32x2_t zn, uint64_t imm)
     __arm_streaming_compatible;
 
 
   // Variants are also available for _u16[_s64_x4]
-  svuint8_t svqrshrun_u8[_s32_x4](svint32x4_t zn, uint64_t imm)
+  svuint8_t svqrshrun[_n]_u8[_s32_x4](svint32x4_t zn, uint64_t imm)
     __arm_streaming;
   ```
 


### PR DESCRIPTION
This patch makes a few tweaks to the SME2 intrinsics:

*   The type suffix of the SME2 svread* intrinsics needs to be
    explicit (non-optional), since there is no merge input that
    can be used to infer it.

*   The zn argument to the svluti* intrinsics is a collection of
    2-bit and 4-bit quantities, so it doesn't have a natural element
    size or signedness.  It seems better to keep it as svuint8_t for
    all variants.

*   Because of that, there is no argument that implies the return
    type of the svluti* intrinsics, so the type suffix needs to be
    explicit.  Also, since the instruction performs a bag-of-bits
    lookup, it makes sense to have floating-point variants too.

*   The ZA slice forms of svread* and svwrite* are likewise
    bag-of-bits moves, so we can provide alternatives for all
    element types.

*   arm_neon.h shift-by-immediate instructions use an _n suffix
    to indicate that the shift amount is scalar.  arm_sve.h
    carried this across to the full/non-overloaded forms of SVE
    immediate shifts.  It seems worth doing the same here for
    consistency, and to protect against vector-vector forms
    being added in future.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
