### PR TITLE
Add ACLE macros for FEAT_PAuth_LR

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -364,7 +364,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   * Added [MOPS](#memcpy-family-of-operations-intrinsics---mops).
 * Introduced the `__ARM_FEATURE_PAUTH_LR` feature macro in section
   [Pointer Authentication](#pointer-authentication) to indicate target support
-  for the Armv9.5a's PAC Enhancements.
+  for the Armv9.5-A's PAC Enhancements.
 * Introduced a new value to the `__ARM_FEATURE_PAC_DEFAULT` macro to indicate
   the use of PC as a diversifier for [Pointer Authentication](#pointer-authentication).
 
@@ -1591,7 +1591,7 @@ mechanisms such as function attributes.
 `__ARM_FEATURE_PAUTH` is defined to 1 if Pointer Authentication extension
 (FEAT_PAuth) is available on the target. It is undefined otherwise.
 
-`__ARM_FEATURE_PAUTH_LR` is defined to 1 if Armv9.5a enhancements to the
+`__ARM_FEATURE_PAUTH_LR` is defined to 1 if Armv9.5-A enhancements to the
 Pointer Authentication extension (FEAT_PAuth_LR) are available on the target.
 It is undefined otherwise.
 
@@ -2296,7 +2296,7 @@ be found in [[BA]](#BA).
 | [`__ARM_FEATURE_NUMERIC_MAXMIN`](#numeric-maximum-and-minimum)                                                                                          | Numeric Maximum and Minimum                                                                        | 1           |
 | [`__ARM_FEATURE_PAC_DEFAULT`](#pointer-authentication)                                                                                                  | Pointer authentication protection                                                                  | 0x5         |
 | [`__ARM_FEATURE_PAUTH`](#pointer-authentication)                                                                                                        | Pointer Authentication Extension (FEAT_PAuth)                                                      | 1           |
-| [`__ARM_FEATURE_PAUTH_LR`](#pointer-authentication)                                                                                                     | Armv9.5a Enhancements to Pointer Authentication Extension (FEAT_PAuth_LR)                          | 1           |
+| [`__ARM_FEATURE_PAUTH_LR`](#pointer-authentication)                                                                                                     | Armv9.5-A Enhancements to Pointer Authentication Extension (FEAT_PAuth_LR)                         | 1           |
 | [`__ARM_FEATURE_QBIT`](#q-saturation-flag)                                                                                                              | Q (saturation) flag (32-bit-only)                                                                  | 1           |
 | [`__ARM_FEATURE_QRDMX`](#rounding-doubling-multiplies)                                                                                                  | SQRDMLxH instructions and associated intrinsics availability                                       | 1           |
 | [`__ARM_FEATURE_RCPC`](#rcpc)                                                                                                                           | Release Consistent processor consistent Model (64-bit-only)                      | 1           |

--- a/main/acle.md
+++ b/main/acle.md
@@ -362,6 +362,11 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added description of SVE reinterpret intrinsics.
 * Changes for [Function Multi Versioning](#function-multi-versioning):
   * Added [MOPS](#memcpy-family-of-operations-intrinsics---mops).
+* Introduced the `__ARM_FEATURE_PAUTH_LR` feature macro in section
+  [Pointer Authentication](#pointer-authentication) to indicate target support
+  for the Armv9.5a's PAC Enhancements.
+* Introduced a new value to the `__ARM_FEATURE_PAC_DEFAULT` macro to indicate
+  the use of PC as a diversifier for [Pointer Authentication](#pointer-authentication).
 
 ### References
 
@@ -1570,11 +1575,12 @@ Pointer Authentication extension to protect code against code reuse attacks
 by default.
 The bits are defined as follows:
 
-| **Bit** | **Meaning**                         |
-| ------- | ----------------------------------- |
-| 0       | Protection using the A key          |
-| 1       | Protection using the B key          |
-| 2       | Protection including leaf functions |
+| **Bit** | **Meaning**                          |
+| ------- | ------------------------------------ |
+| 0       | Protection using the A key           |
+| 1       | Protection using the B key           |
+| 2       | Protection including leaf functions  |
+| 3       | Protection using PC as a diversifier |
 
 For example, a value of `0x5` indicates that the Pointer Authentication
 extension is used to protect function entry points, including leaf functions,
@@ -1583,7 +1589,11 @@ The protection applied to any particular function may be overridden by
 mechanisms such as function attributes.
 
 `__ARM_FEATURE_PAUTH` is defined to 1 if Pointer Authentication extension
-is available on the target. It is undefined otherwise.
+(FEAT_PAuth) is available on the target. It is undefined otherwise.
+
+`__ARM_FEATURE_PAUTH_LR` is defined to 1 if Armv9.5a enhancements to the
+Pointer Authentication extension (FEAT_PAuth_LR) are available on the target.
+It is undefined otherwise.
 
 ### Large System Extensions
 
@@ -2284,7 +2294,9 @@ be found in [[BA]](#BA).
 | [`__ARM_FEATURE_MOPS`](#memcpy-family-of-memory-operations-standarization-instructions---mops)                                                          | `memcpy`, `memset`, and `memmove` family of operations standardization instructions               | 1           |
 | [`__ARM_FEATURE_MVE`](#m-profile-vector-extension)                                                                                                      | M-profile Vector Extension                                                                         | 1           |
 | [`__ARM_FEATURE_NUMERIC_MAXMIN`](#numeric-maximum-and-minimum)                                                                                          | Numeric Maximum and Minimum                                                                        | 1           |
-| [`__ARM_FEATURE_PAC_DEFAULT`](#pointer-authentication)                                                                                                  | Pointer authentication                                                                             | 0x5         |
+| [`__ARM_FEATURE_PAC_DEFAULT`](#pointer-authentication)                                                                                                  | Pointer authentication protection                                                                  | 0x5         |
+| [`__ARM_FEATURE_PAUTH`](#pointer-authentication)                                                                                                        | Pointer Authentication Extension (FEAT_PAuth)                                                      | 1           |
+| [`__ARM_FEATURE_PAUTH_LR`](#pointer-authentication)                                                                                                     | Armv9.5a Enhancements to Pointer Authentication Extension (FEAT_PAuth_LR)                          | 1           |
 | [`__ARM_FEATURE_QBIT`](#q-saturation-flag)                                                                                                              | Q (saturation) flag (32-bit-only)                                                                  | 1           |
 | [`__ARM_FEATURE_QRDMX`](#rounding-doubling-multiplies)                                                                                                  | SQRDMLxH instructions and associated intrinsics availability                                       | 1           |
 | [`__ARM_FEATURE_RCPC`](#rcpc)                                                                                                                           | Release Consistent processor consistent Model (64-bit-only)                      | 1           |


### PR DESCRIPTION
The Armv9.5a introduces the FEAT_PAuth_LR extension, adding an enhancement
to the Pointer Authentication extension where the value of PC is used as
a diversifier when signing pointers.

This updates the ACLE to support the extension by the introduction of a
new feature macro and the addition of a new possible value to the
existing `__ARM_FEATURE_PAC_DEFAULT` macro.
