### PR TITLE
Define new value for the __ARM_ACLE macro

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -1315,13 +1315,23 @@ enclose them in parentheses if they are not simple constants.
 
 ## Testing for Arm C Language Extensions
 
-`__ARM_ACLE` is defined to the version of this specification implemented,
-formatted as `{YEAR}{QUARTER}{PATCH}`. Examples:
+`__ARM_ACLE` is defined as the version of this specification that is
+implemented, formatted as `{YEAR}{QUARTER}{PATCH}`. The `YEAR` segment is
+composed of 4 digits, the `QUARTER` segment is composed of 1 digit, and
+the `PATCH` segment is also composed of 1 digit.
+
+For example:
 
  - An implementation based on the version 2023 Q2 of the ACLE with no
    further patch releases will define `__ARM_ACLE` as `202320`.
  - An implementation based on a hypothetical version 2024 Q3 of the ACLE
    with two patch releases will define `__ARM_ACLE` as `202432`.
+
+NOTE: Previously, the macro followed the previous versioning scheme and
+was defined as `100 * major_version + minor_version`, which was the
+version of this specification implemented. For instance, an implementation
+implementing version 2.1 of the ACLE specification defined `__ARM_ACLE`
+as `201`.
 
 ## Endianness
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -1313,10 +1313,13 @@ enclose them in parentheses if they are not simple constants.
 
 ## Testing for Arm C Language Extensions
 
-`__ARM_ACLE` is defined to the version of this specification
-implemented, as `100 * major_version + minor_version`. An implementation
-implementing version 2.1 of the ACLE specification will define
-`__ARM_ACLE` as 201.
+`__ARM_ACLE` is defined to the version of this specification implemented,
+formatted as `{YEAR}{QUARTER}{PATCH}`. Examples:
+
+ - An implementation based on the version 2023 Q2 of the ACLE with no
+   further patch releases will define `__ARM_ACLE` as `202320`.
+ - An implementation based on a hypothetical version 2024 Q3 of the ACLE
+   with two patch releases will define `__ARM_ACLE` as `202432`.
 
 ## Endianness
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -353,6 +353,8 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 
 #### Changes for next release
 
+* Changed the definition of the `__ARM_ACLE` macro to reflect the current
+  versioning scheme.
 * Combined the SME `slice_base` and `slice_offset` arguments into a
   single `slice` argument.
 * Added the [Keyword attributes](#keyword-attributes) section.


### PR DESCRIPTION
The ACLE defines a feature macro called __ARM_ACLE:

__ARM_ACLE is defined to the version of this specification implemented, as 100 * major_version + minor_version. An implementation implementing version 2.1 of the ACLE specification will define __ARM_ACLE as 201.

However, a long time ago, we changed the versioning scheme of the ACLE from "major.minor" to a combination of year and quarter. For instance the latest release is 2023 Q2.

Since the macro's definition is now out of date, we now move to a new scheme:

`__ARM_ACLE` is defined to the version of this specification implemented, formatted as `{YEAR}{QUARTER}{PATCH}`.

The value would be the integer formed by the year (4 digits) concatenated to the quarter's number (1 digit), finally concatenated to the patch release (1 digit). So the macro's value for the 2023 Q2 release with no patch release would then be 202320. Using 4 digits for the year, and having it preceding the quarter, will be helpful to ensure the formed integer values will be greater than the ones using the previous/current format.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [x] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [x] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [x] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
