### PR TITLE
Promote the SME(2) ACLE status from Alpha to Beta

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -372,6 +372,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added a [State management](#state-management) section, replacing the
   `__arm_shared_za`, `__arm_new_za`, and `__arm_preserves_za` attributes
   in the previous Alpha SME spec.
+* Changed the status of the SME ACLE from Alpha to Beta.
 
 ### References
 
@@ -754,7 +755,7 @@ start with the prefix `__ARM`.
 ## Keyword attributes
 
 This section is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may change or be
+[**Beta** state](#current-status-and-anticipated-changes) and may change or be
 extended in the future.
 
 ACLE adds several non-standard keywords to C and C++. These keywords
@@ -1036,7 +1037,7 @@ header:
 ### `<arm_sme.h>`
 
 The specification for SME is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may
+[**Beta** state](#current-status-and-anticipated-changes) and may
 change or be extended in the future.
 
 `<arm_sme.h>` declares functions and defines intrinsics for SME
@@ -1828,7 +1829,7 @@ intrinsics are available. This implies that the following macros are nonzero:
 #### Scalable Matrix Extension (SME)
 
 The specification for SME is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may
+[**Beta** state](#current-status-and-anticipated-changes) and may
 change or be extended in the future.
 
 `__ARM_FEATURE_SME` is defined to 1 if there is hardware support
@@ -2116,7 +2117,7 @@ following it. --><span id="16-bit-to-64-bit-integer-widening-outer-product-intri
 #### 16-bit to 64-bit integer widening outer product intrinsics
 
 The specification for SME is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may change or be
+[**Beta** state](#current-status-and-anticipated-changes) and may change or be
 extended in the future.
 
 `__ARM_FEATURE_SME_I16I64` is defined to `1` if there is hardware
@@ -2127,7 +2128,7 @@ available. This implies that `__ARM_FEATURE_SME` is nonzero.
 #### Double precision floating-point outer product intrinsics
 
 The specification for SME is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may change or be
+[**Beta** state](#current-status-and-anticipated-changes) and may change or be
 extended in the future.
 
 `__ARM_FEATURE_SME_F64F64` is defined to `1` if there is hardware
@@ -4596,7 +4597,7 @@ The tag bits in the input pointers are ignored for this operation.
 # State management
 
 The specification for SME is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may change or be
+[**Beta** state](#current-status-and-anticipated-changes) and may change or be
 extended in the future.
 
 ## Introduction
@@ -8596,7 +8597,7 @@ when move instructions are required.
 # SME language extensions and intrinsics
 
 The specification for SME is in
-[**Alpha** state](#current-status-and-anticipated-changes) and may change or be
+[**Beta** state](#current-status-and-anticipated-changes) and may change or be
 extended in the future.
 
 ## Controlling the use of streaming mode


### PR DESCRIPTION
The SME and SME2 ACLE have been implemented in upstream GCC and Clang/LLVM, so I think they're ready to be treated as Beta.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
