### PR TITLE
Introduce __ARM_ACLE_VERSION macro.

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -355,6 +355,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 
 * Changed the definition of the `__ARM_ACLE` macro to reflect the current
   versioning scheme.
+* Added `__ARM_ACLE_VERSION` to express a given ACLE version.
 * Combined the SME `slice_base` and `slice_offset` arguments into a
   single `slice` argument.
 * Added the [Keyword attributes](#keyword-attributes) section.
@@ -1346,6 +1347,10 @@ was defined as `100 * major_version + minor_version`, which was the
 version of this specification implemented. For instance, an implementation
 implementing version 2.1 of the ACLE specification defined `__ARM_ACLE`
 as `201`.
+
+`__ARM_ACLE_VERSION(year, quarter, patch)` is defined to express a given
+ACLE version. Returns with the version number in the same format as the
+`__ARM_ACLE` does.
 
 ## Endianness
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -1350,7 +1350,12 @@ as `201`.
 
 `__ARM_ACLE_VERSION(year, quarter, patch)` is defined to express a given
 ACLE version. Returns with the version number in the same format as the
-`__ARM_ACLE` does.
+`__ARM_ACLE` does. Checking the minimum required ACLE version could be
+written as:
+
+``` c
+#if __ARM_ACLE >= __ARM_ACLE_VERSION(2024, 1, 0)
+```
 
 ## Endianness
 


### PR DESCRIPTION
Implements #297. 
This could be more valuable in cooperation with #301.

Checklist: (mark with ``X`` those which apply)

* [x] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [x] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
