### PR TITLE
[FMV] Allow mixing target_version with target_clones.

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -363,6 +363,11 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
   to use keyword attributes instead of GNU-style attributes.
 * Added description of SVE reinterpret intrinsics.
 * Changes and fixes for [Function Multi Versioning](#function-multi-versioning):
+  * Combination of attributes `target_version` and `target_clones` is allowed.
+  * Clarify the existance of a single default version across all translation
+    units with the explicitly provided version being the preferred in case
+    `target_version` and `target_clones` are mixed.
+  * Emphasise that all instances of the versions share the same calling convention.
   * Changed the mangling rules [Name mangling](#name-mangling), such that
     feature names are appended in lexicographic order, not in priority order.
   * Mangled names contain a unique set of features (no duplicates).
@@ -2474,11 +2479,11 @@ The following attributes trigger the multi version code generation:
 `__attribute__((target_version("name")))` and
 `__attribute__((target_clones("name",...)))`.
 
-* These attributes can't be mixed with each other.
+* These attributes can be mixed with each other.
 * The `default` version means the version of the function that would
   be generated without these attributes.
 * `name` is the dependent features from the tables below.
-  * If a feature depends on an other feature as defined by the Architecture
+  * If a feature depends on another feature as defined by the Architecture
     Reference Manual then no need to explicitly state in the attribute[^fmv-note-names].
 * The dependent features could be joined by the `+` sign.
 * None of these attributes will enable the corresponding ACLE feature(s)
@@ -2498,11 +2503,15 @@ following:
 * when applied to a function it becomes one of the versions. Function
   with the same name may exist with multiple versions in the same
   translation unit.
-* One `default` version of the function is required to be provided.
+* Function versions may reside in different translation units.
+* Each version declaration should be visible at the translation
+  unit in which the corresponding function version resides.
+* One `default` version of the function is required to be provided
+  in one of the translation units.
   * Implicitly, without this attribute,
   * or explicitly providing the `default` in the attribute.
 * All instances of the versions shall share the same function
-  signature.
+  signature and calling convention.
 
 The attribute `__attribute__((target_clones("name",...)))` expresses the
 following:
@@ -2510,9 +2519,10 @@ following:
 * when applied to a function the compiler emits multiple versions
   based on the arguments.
   * One of them is implicitly the `default`.
-  * If the `default` matches with an other explicitly provided
-    version the compiler can emit only one function instead of the
-    two.
+  * If the `default` matches with another explicitly provided
+    version in the same translation unit, then the compiler can
+    emit only one function instead of the two. The explicitly
+    provided version shall be preferred.
 * If a name is not recognized the compiler should ignore it[^fmv-note-ignore].
 
 [^fmv-note-ignore]: The intention is to support the usecase of newer code if


### PR DESCRIPTION
The combination of these attributes is now permitted. Therefore, it is
also worth clarifying the existance of a single default version across
all translation units with the explicitly provided version being the
preferred in case `target_version` and `target_clones` are mixed.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
