### PR TITLE
Remove request for preprocessor guards from header files.

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -1074,24 +1074,23 @@ header, but this might limit function multi-versioning capabilities:
 
 Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).
 
-These macro features:
-`__ARM_ACLE`, `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC`, `__ARM_FEATURE_BF16`,
-`__ARM_NEON`, `__ARM_FEATURE_SVE` and ` __ARM_FEATURE_SME`
-represent a compiler's ability to use the instructions associated
-with the feature via ACLE documented builtins and within inline assembly.
-They may also be influenced by source code mechanisms like `#pragma` or
-`attribute`, but users should not rely on this. They are defined for user
-convenience.
+### Predefined Macros and Headers
+
+The macros can represent a compiler's ability to use the instructions
+associated with the feature via ACLE documented intrinsics and within inline
+assembly. However users should not rely solely on macro definition, because
+there are intrinsics that may be influenced by mechanisms like `#pragma` or
+`attribute`. The macros are defined only for user convenience.
 
 For example:
 
 ``` c
    #ifdef __ARM_FEATURE_SME
    #include<arm_sme.h>
+     void foo(svbool_t pg, void *ptr, uint32_t slice_base) {
+        svst1_hor_za8(0, slice_base, pg, ptr);
+      }
    #endif
-   void foo(svbool_t pg, void *ptr, uint32_t slice_base) {
-      svst1_hor_za8(0, slice_base, pg, ptr);
-   }
 ```
 
 `foo`  uses `__ARM_FEATURE_SME` to have available SME intriniscs,

--- a/main/acle.md
+++ b/main/acle.md
@@ -1085,10 +1085,14 @@ Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).
 
 ### Predefined feature macros and header files
 
-Testing a feature macro returns the compiler's availability for the feature via ACLE
-documented intrinsics and inline assembly. This property can be independent of
-where the test is performed, meaning a feature macro does not guarantee the
-validity of using the feature at the point it is tested. For example:
+Feature macros indicate whether that feature's intrinsics and inline assembly instructions
+are available in normal unannotated functions. In some implementations, the macro definitions
+are invariant throughout a translation unit, while in other implementations, the macro
+definitions can vary with pragmas.
+
+The macro definitions are otherwise independent of where the test is performed,
+meaning that a feature macro does not guarantee that the feature can be used at the
+point that it is tested. For example:
 
 ``` c
     #include <arm_sme.h>
@@ -1100,10 +1104,9 @@ validity of using the feature at the point it is tested. For example:
     }
 ```
 
-Whilst testing `__ARM_FEATURE_SME` ensures the compiler has available the SME
-intrinsic `svst1_hor_za8`, `foo` will fail to compile because it has not been
-decorated with the necessary keywords to guarantee the function will be
-executed in streaming mode.
+While testing `__ARM_FEATURE_SME` ensures that the SME intrinsic `svst1_hor_za8`
+is available, `foo` will fail to compile because the call does not occur in a
+[streaming statement](#streaming-statement).
 
 Not all such issues can be caught during compilation and may instead result in
 runtime failures.

--- a/main/acle.md
+++ b/main/acle.md
@@ -1075,10 +1075,9 @@ Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).
 
 ### Predefined feature macros and header files
 
-Testing a feature macro returns the compiler's availability for the feature
-via ACLE documented intrinsics and inline assembly. This property can be
-independent of where the test is performed. There should be no assumption on
-the order or context in wich the preprocessor macros are evaluated.
+Evaluating a feature macro returns the availability of intrinsics and inline
+assembly for that feature, but no assumptions should be made on the order or
+context in which the preprocessor macros are evaluated.
 
 The compiler may add additional restrictions to the intrinsics beyond what is
 captured by the ACLE macros depending on the context in which the intrinsics
@@ -1093,8 +1092,8 @@ are used. For example:
     }
 ```
 
-While testing `__ARM_FEATURE_SME` ensures that the SME intrinsic `svst1_hor_za8`
-is available, `foo` will fail to compile because the call does not occur in a
+If `__ARM_FEATURE_SME` evaluates to `true` the SME intrinsic `svst1_hor_za8`
+is available, but `foo` may still fail to compile because the call does not occur in a
 [streaming statement](#streaming-statement).
 
 ## Attributes

--- a/main/acle.md
+++ b/main/acle.md
@@ -1003,7 +1003,8 @@ Including `<arm_sve.h>` also includes the following header files:
 
 `<arm_neon_sve_bridge.h>` defines intrinsics for moving data between
 Neon and SVE vector types; see [NEON-SVE Bridge](#neon-sve-bridge)
-for details.
+for details. The `__ARM_NEON_SVE_BRIDGE` macro should be tested
+-before including the header:
 
 ``` c
   #ifdef __ARM_NEON_SVE_BRIDGE

--- a/main/acle.md
+++ b/main/acle.md
@@ -925,8 +925,9 @@ and:
 to the more specific header files below. These intrinsics are in the
 C implementation namespace and begin with double underscores. It is
 unspecified whether they are available without the header being
-included. The `__ARM_ACLE` macro can be tested before including the
-header, but this might limit function multi-versioning capabilities:
+included. The `__ARM_ACLE` macro can be tested before including the header.
+However, this is not recommended for cases where target feature selection is
+overridden within code, for example, when using #function-multi-versioning.
 
 ``` c
   #ifdef __ARM_ACLE
@@ -939,9 +940,10 @@ header, but this might limit function multi-versioning capabilities:
 `<arm_fp16.h>` is provided to define the scalar 16-bit floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` macro can be
-tested before including the header, but this might limit function
-multi-versioning capabilities:
+included. The `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` macro can be tested before
+including the header. However, this is not recommended for cases where target
+feature selection is overridden within code, for example, when using
+#function-multi-versioning.
 
 ``` c
   #ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
@@ -954,8 +956,10 @@ multi-versioning capabilities:
 `<arm_bf16.h>` is provided to define the 16-bit brain floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_BF16` macro can be tested before including
-the header, but this might limit function multi-versioning capabilities:
+included. The `__ARM_FEATURE_BF16` macro can be tested before including the
+header. However, this is not recommended for cases where target feature
+selection is overridden within code, for example, when using
+function-multi-versioning.
 
 ``` c
   #ifdef __ARM_FEATURE_BF16
@@ -977,8 +981,10 @@ intrinsics](#advanced-simd-neon-intrinsics) and associated
 [data types](#vector-data-types). As these intrinsics and data types are
 in the user namespace, an implementation would not normally define them
 until the header is included. The `__ARM_NEON` macro can be tested before
-including the header, but this might limit function multi-versioning
-capabilities:
+including the header. However, this is not recommended for cases where target
+feature selection is overridden within code, for example, when using
+#function-multi-versioning.
+
 
 ``` c
   #ifdef __ARM_NEON
@@ -1001,8 +1007,9 @@ following it. --><span id="arm_sve.h"></span>
 `<arm_sve.h>` defines data types and intrinsics for SVE and its
 extensions; see [SVE language extensions and
 intrinsics](#sve-language-extensions-and-intrinsics) for details.
-The `__ARM_FEATURE_SVE` macro can be tested before including the header,
-but this might limit function multi-versioning capabilities:
+The `__ARM_FEATURE_SVE` macro can be tested before including the header.
+However, this is not recommended for cases where target feature selection is
+overridden within code, for example, when using #function-multi-versioning.
 
 ``` c
   #ifdef __ARM_FEATURE_SVE
@@ -1064,7 +1071,9 @@ change or be extended in the future.
 `<arm_sme.h>` declares functions and defines intrinsics for SME
 and its extensions; see [SME language extensions and intrinsics](#sme-language-extensions-and-intrinsics)
 for details. The `__ARM_FEATURE_SME` macro can be tested before including the
-header, but this might limit function multi-versioning capabilities:
+header. However, this is not recommended for cases where target feature
+selection is overridden within code, for example, when using
+#function-multi-versioning.
 
 ``` c
   #ifdef __ARM_FEATURE_SME
@@ -1074,31 +1083,30 @@ header, but this might limit function multi-versioning capabilities:
 
 Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).
 
-### Predefined Macros and Headers
+### Predefined feature macros and header files
 
-The macros can represent a compiler's ability to use the instructions
-associated with the feature via ACLE documented intrinsics and within inline
-assembly. However users should not rely solely on macro definition, because
-there are intrinsics that may be influenced by mechanisms like `#pragma` or
-`attribute`. The macros are defined only for user convenience.
-
-For example:
+Testing a feature macro returns the compiler's availability for the feature via ACLE
+documented intrinsics and inline assembly. This property can be independent of
+where the test is performed, meaning a feature macro does not guarantee the
+validity of using the feature at the point it is tested. For example:
 
 ``` c
-   #ifdef __ARM_FEATURE_SME
-   #include<arm_sme.h>
-     void foo(svbool_t pg, void *ptr, uint32_t slice_base) {
-        svst1_hor_za8(0, slice_base, pg, ptr);
-      }
-   #endif
+    #include <arm_sme.h>
+
+    void foo(svbool_t pg, void *ptr, uint32_t slice_base) {
+    #ifdef __ARM_FEATURE_SME
+      svst1_hor_za8(0, slice_base, pg, ptr);
+    #endif
+    }
 ```
 
-`foo`  uses `__ARM_FEATURE_SME` to have available SME intriniscs,
-like `svst1_hor_za8`. However it has the compilation error:
-`builtin can only be called from a streaming function`
-for the command line:
-`armclang -O3 -target aarch64-linux-gnu -march=armv8-a+sme`
-that defines `__ARM_FEATURE_SME` to one.
+Whilst testing `__ARM_FEATURE_SME` ensures the compiler has available the SME
+intrinsic `svst1_hor_za8`, `foo` will fail to compile because it has not been
+decorated with the necessary keywords to guarantee the function will be
+executed in streaming mode.
+
+Not all such issues can be caught during compilation and may instead result in
+runtime failures.
 
 ## Attributes
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -913,8 +913,8 @@ and:
 
 ``` c
   #include <arm_neon.h>
-  #define __STDC_FORMAT_MACROS
   ...
+  #define __STDC_FORMAT_MACROS
   #include <stdint.h>
   // ... UINT64_C is now defined
 ```

--- a/main/acle.md
+++ b/main/acle.md
@@ -940,7 +940,7 @@ guaranteed to be available.
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
 included. When `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` is defined to `1`,
-the header file is available in a normal unannotated function.
+the header file is guaranteed to be available.
 
 ``` c
   #ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
@@ -954,7 +954,7 @@ the header file is available in a normal unannotated function.
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
 included. The `__ARM_FEATURE_BF16` is defined to `1`, the header file is
-available in a normal unannotated function.
+guaranteed to be available in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_BF16
@@ -976,7 +976,7 @@ intrinsics](#advanced-simd-neon-intrinsics) and associated
 [data types](#vector-data-types). As these intrinsics and data types are
 in the user namespace, an implementation would not normally define them
 until the header is included. The `__ARM_NEON` is defined to `1`,
-the header file is available in a normal unannotated function.
+the header file is guaranteed to be available in a normal unannotated function.
 
 
 ``` c
@@ -1000,8 +1000,8 @@ following it. --><span id="arm_sve.h"></span>
 `<arm_sve.h>` defines data types and intrinsics for SVE and its
 extensions; see [SVE language extensions and
 intrinsics](#sve-language-extensions-and-intrinsics) for details.
-The `__ARM_FEATURE_SVE` is defined to `1`, the header file is available
-in a normal unannotated function.
+The `__ARM_FEATURE_SVE` is defined to `1`, the header file is guaranteed to be
+available in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_SVE
@@ -1063,7 +1063,7 @@ change or be extended in the future.
 `<arm_sme.h>` declares functions and defines intrinsics for SME
 and its extensions; see [SME language extensions and intrinsics](#sme-language-extensions-and-intrinsics)
 for details. The `__ARM_FEATURE_SME` is defined to `1`,
-the header file is available in a normal unannotated function.
+the header file is guaranteed to be available in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_SME
@@ -1077,7 +1077,17 @@ Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).
 
 Evaluating a feature macro returns the availability of intrinsics and inline
 assembly for that feature, but no assumptions should be made on the order or
-context in which the preprocessor macros are evaluated.
+context in which the preprocessor macros are evaluated. For example:
+
+``` c
+    __attribute__((target("+sve")))
+    void foo() {
+    #ifdef __ARM_FEATURE_SVE
+      // The user should make no assumptions that the target attribute
+     // has enabled the __ARM_FEATURE_SVE macro.
+    #endif
+}
+```
 
 The compiler may add additional restrictions to the intrinsics beyond what is
 captured by the ACLE macros depending on the context in which the intrinsics
@@ -1093,8 +1103,8 @@ are used. For example:
 ```
 
 If `__ARM_FEATURE_SME` evaluates to `true` the SME intrinsic `svst1_hor_za8`
-is available, but `foo` may still fail to compile because the call does not occur in a
-[streaming statement](#streaming-statement).
+is available, but `foo` may still fail to compile because the call does not
+occur in a [streaming statement](#streaming-statement).
 
 ## Attributes
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -925,9 +925,8 @@ and:
 to the more specific header files below. These intrinsics are in the
 C implementation namespace and begin with double underscores. It is
 unspecified whether they are available without the header being
-included. The `__ARM_ACLE` macro can be tested before including the header.
-However, this is not recommended for cases where target feature selection is
-overridden within code, for example, when using #function-multi-versioning.
+included. When `__ARM_ACLE` is defined to `1`, the header file is
+guaranteed to be available.
 
 ``` c
   #ifdef __ARM_ACLE
@@ -940,10 +939,8 @@ overridden within code, for example, when using #function-multi-versioning.
 `<arm_fp16.h>` is provided to define the scalar 16-bit floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` macro can be tested before
-including the header. However, this is not recommended for cases where target
-feature selection is overridden within code, for example, when using
-#function-multi-versioning.
+included. When `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` is defined to `1`,
+the header file is available in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
@@ -956,10 +953,8 @@ feature selection is overridden within code, for example, when using
 `<arm_bf16.h>` is provided to define the 16-bit brain floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_BF16` macro can be tested before including the
-header. However, this is not recommended for cases where target feature
-selection is overridden within code, for example, when using
-function-multi-versioning.
+included. The `__ARM_FEATURE_BF16` is defined to `1`, the header file is
+available in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_BF16
@@ -980,10 +975,8 @@ instructions available are conversion intrinsics between `bfloat16_t` and
 intrinsics](#advanced-simd-neon-intrinsics) and associated
 [data types](#vector-data-types). As these intrinsics and data types are
 in the user namespace, an implementation would not normally define them
-until the header is included. The `__ARM_NEON` macro can be tested before
-including the header. However, this is not recommended for cases where target
-feature selection is overridden within code, for example, when using
-#function-multi-versioning.
+until the header is included. The `__ARM_NEON` is defined to `1`,
+the header file is available in a normal unannotated function.
 
 
 ``` c
@@ -1007,9 +1000,8 @@ following it. --><span id="arm_sve.h"></span>
 `<arm_sve.h>` defines data types and intrinsics for SVE and its
 extensions; see [SVE language extensions and
 intrinsics](#sve-language-extensions-and-intrinsics) for details.
-The `__ARM_FEATURE_SVE` macro can be tested before including the header.
-However, this is not recommended for cases where target feature selection is
-overridden within code, for example, when using #function-multi-versioning.
+The `__ARM_FEATURE_SVE` is defined to `1`, the header file is available
+in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_SVE
@@ -1070,10 +1062,8 @@ change or be extended in the future.
 
 `<arm_sme.h>` declares functions and defines intrinsics for SME
 and its extensions; see [SME language extensions and intrinsics](#sme-language-extensions-and-intrinsics)
-for details. The `__ARM_FEATURE_SME` macro can be tested before including the
-header. However, this is not recommended for cases where target feature
-selection is overridden within code, for example, when using
-#function-multi-versioning.
+for details. The `__ARM_FEATURE_SME` is defined to `1`,
+the header file is available in a normal unannotated function.
 
 ``` c
   #ifdef __ARM_FEATURE_SME
@@ -1085,18 +1075,17 @@ Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).
 
 ### Predefined feature macros and header files
 
-Feature macros indicate whether that feature's intrinsics and inline assembly instructions
-are available in normal unannotated functions. In some implementations, the macro definitions
-are invariant throughout a translation unit, while in other implementations, the macro
-definitions can vary with pragmas.
+Testing a feature macro returns the compiler's availability for the feature
+via ACLE documented intrinsics and inline assembly. This property can be
+independent of where the test is performed. There should be no assumption on
+the order or context in wich the preprocessor macros are evaluated.
 
-The macro definitions are otherwise independent of where the test is performed,
-meaning that a feature macro does not guarantee that the feature can be used at the
-point that it is tested. For example:
+The compiler may add additional restrictions to the intrinsics beyond what is
+captured by the ACLE macros depending on the context in which the intrinsics
+are used. For example:
 
 ``` c
     #include <arm_sme.h>
-
     void foo(svbool_t pg, void *ptr, uint32_t slice_base) {
     #ifdef __ARM_FEATURE_SME
       svst1_hor_za8(0, slice_base, pg, ptr);
@@ -1107,9 +1096,6 @@ point that it is tested. For example:
 While testing `__ARM_FEATURE_SME` ensures that the SME intrinsic `svst1_hor_za8`
 is available, `foo` will fail to compile because the call does not occur in a
 [streaming statement](#streaming-statement).
-
-Not all such issues can be caught during compilation and may instead result in
-runtime failures.
 
 ## Attributes
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -940,7 +940,8 @@ guaranteed to be available.
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
 included. When `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` is defined to `1`,
-the header file is guaranteed to be available.
+the header file is available regardless of the context in which the macro
+is evaluated.
 
 ``` c
   #ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
@@ -953,8 +954,9 @@ the header file is guaranteed to be available.
 `<arm_bf16.h>` is provided to define the 16-bit brain floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_BF16` is defined to `1`, the header file is
-guaranteed to be available in a normal unannotated function.
+included. When `__ARM_FEATURE_BF16` is defined to `1`, the header file is
+guaranteed to be available regardless of the context in which the macro
+is evaluated.
 
 ``` c
   #ifdef __ARM_FEATURE_BF16
@@ -975,8 +977,9 @@ instructions available are conversion intrinsics between `bfloat16_t` and
 intrinsics](#advanced-simd-neon-intrinsics) and associated
 [data types](#vector-data-types). As these intrinsics and data types are
 in the user namespace, an implementation would not normally define them
-until the header is included. The `__ARM_NEON` is defined to `1`,
-the header file is guaranteed to be available in a normal unannotated function.
+until the header is included. When `__ARM_NEON` is defined to `1`,
+the header file is available regardless of the context in which the macro is
+evaluated.
 
 
 ``` c
@@ -1000,8 +1003,8 @@ following it. --><span id="arm_sve.h"></span>
 `<arm_sve.h>` defines data types and intrinsics for SVE and its
 extensions; see [SVE language extensions and
 intrinsics](#sve-language-extensions-and-intrinsics) for details.
-The `__ARM_FEATURE_SVE` is defined to `1`, the header file is guaranteed to be
-available in a normal unannotated function.
+When `__ARM_FEATURE_SVE` is defined to `1`, the header file is available
+regardless of the context in which the macro is evaluated.
 
 ``` c
   #ifdef __ARM_FEATURE_SVE
@@ -1062,8 +1065,8 @@ change or be extended in the future.
 
 `<arm_sme.h>` declares functions and defines intrinsics for SME
 and its extensions; see [SME language extensions and intrinsics](#sme-language-extensions-and-intrinsics)
-for details. The `__ARM_FEATURE_SME` is defined to `1`,
-the header file is guaranteed to be available in a normal unannotated function.
+for details. When `__ARM_FEATURE_SME` is defined to `1`, the header file is
+available regardless of the context in which the macro is evaluated.
 
 ``` c
   #ifdef __ARM_FEATURE_SME

--- a/main/acle.md
+++ b/main/acle.md
@@ -904,6 +904,7 @@ correctly:
 
 ``` c
   #include <stdint.h>
+  // UINT64_C not defined here since we did not set __STDC_FORMAT_MACROS
   ...
   #include <arm_neon.h>
 ```
@@ -912,8 +913,10 @@ and:
 
 ``` c
   #include <arm_neon.h>
+  #define __STDC_FORMAT_MACROS
   ...
   #include <stdint.h>
+  // ... UINT64_C is now defined
 ```
 
 ### `<arm_acle.h>`

--- a/main/acle.md
+++ b/main/acle.md
@@ -1004,7 +1004,7 @@ Including `<arm_sve.h>` also includes the following header files:
 `<arm_neon_sve_bridge.h>` defines intrinsics for moving data between
 Neon and SVE vector types; see [NEON-SVE Bridge](#neon-sve-bridge)
 for details. The `__ARM_NEON_SVE_BRIDGE` macro should be tested
--before including the header:
+before including the header:
 
 ``` c
   #ifdef __ARM_NEON_SVE_BRIDGE

--- a/main/acle.md
+++ b/main/acle.md
@@ -904,7 +904,6 @@ correctly:
 
 ``` c
   #include <stdint.h>
-  // UINT64_C not defined here since we did not set __STDC_FORMAT_MACROS
   ...
   #include <arm_neon.h>
 ```
@@ -914,9 +913,7 @@ and:
 ``` c
   #include <arm_neon.h>
   ...
-  #define __STDC_FORMAT_MACROS
   #include <stdint.h>
-  // ... UINT64_C is now defined
 ```
 
 ### `<arm_acle.h>`
@@ -925,13 +922,10 @@ and:
 to the more specific header files below. These intrinsics are in the
 C implementation namespace and begin with double underscores. It is
 unspecified whether they are available without the header being
-included. The `__ARM_ACLE` macro should be tested before including the
-header:
+included.
 
 ``` c
-  #ifdef __ARM_ACLE
   #include <arm_acle.h>
-  #endif /* __ARM_ACLE */
 ```
 
 ### `<arm_fp16.h>`
@@ -939,13 +933,10 @@ header:
 `<arm_fp16.h>` is provided to define the scalar 16-bit floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_FP16_SCALAR_ARITHMETIC` feature macro
-should be tested before including the header:
+included.
 
 ``` c
-  #ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
   #include <arm_fp16.h>
-  #endif /* __ARM_FEATURE_FP16_SCALAR_ARITHMETIC */
 ```
 
 ### `<arm_bf16.h>`
@@ -953,13 +944,10 @@ should be tested before including the header:
 `<arm_bf16.h>` is provided to define the 16-bit brain floating point
 arithmetic intrinsics. As these intrinsics are in the user namespace,
 an implementation would not normally define them until the header is
-included. The `__ARM_FEATURE_BF16` feature macro
-should be tested before including the header:
+included.
 
 ``` c
-  #ifdef __ARM_FEATURE_BF16
   #include <arm_bf16.h>
-  #endif /* __ARM_FEATURE_BF16 */
 ```
 
 When `__ARM_BF16_FORMAT_ALTERNATIVE` is defined to `1` the only scalar
@@ -975,13 +963,10 @@ instructions available are conversion intrinsics between `bfloat16_t` and
 intrinsics](#advanced-simd-neon-intrinsics) and associated
 [data types](#vector-data-types). As these intrinsics and data types are
 in the user namespace, an implementation would not normally define them
-until the header is included. The `__ARM_NEON` macro should be tested
-before including the header:
+until the header is included.
 
 ``` c
-  #ifdef __ARM_NEON
   #include <arm_neon.h>
-  #endif /* __ARM_NEON */
 ```
 
 Including `<arm_neon.h>` will also cause the following header files
@@ -999,13 +984,9 @@ following it. --><span id="arm_sve.h"></span>
 `<arm_sve.h>` defines data types and intrinsics for SVE and its
 extensions; see [SVE language extensions and
 intrinsics](#sve-language-extensions-and-intrinsics) for details.
-You should test the `__ARM_FEATURE_SVE` macro before including the
-header:
 
 ``` c
-  #ifdef __ARM_FEATURE_SVE
   #include <arm_sve.h>
-  #endif /* __ARM_FEATURE_SVE */
 ```
 
 Including `<arm_sve.h>` also includes the following header files:
@@ -1019,13 +1000,10 @@ Including `<arm_sve.h>` also includes the following header files:
 
 `<arm_neon_sve_bridge.h>` defines intrinsics for moving data between
 Neon and SVE vector types; see [NEON-SVE Bridge](#neon-sve-bridge)
-for details.  The `__ARM_NEON_SVE_BRIDGE` macro should be tested
-before including the header:
+for details.
 
 ``` c
-  #ifdef __ARM_NEON_SVE_BRIDGE
   #include <arm_neon_sve_bridge.h>
-  #endif /* __ARM_NEON_SVE_BRIDGE */
 ```
 
 Including `<arm_neon_sve_bridge.h>` will also include
@@ -1040,17 +1018,8 @@ intrinsics occupy both the user namespace and the `__arm_` namespace;
 defining `__ARM_MVE_PRESERVE_USER_NAMESPACE` will hide the definition of
 the user namespace variants.
 
-The `__ARM_FEATURE_MVE` macro should be tested before including the
-header:
-
 ``` c
-  #if (__ARM_FEATURE_MVE & 3) == 3
   #include <arm_mve.h>
-  /* MVE integer and floating point intrinsics are now available to use.  */
-  #elif __ARM_FEATURE_MVE & 1
-  #include <arm_mve.h>
-  /* MVE integer intrinsics are now available to use.  */
-  #endif
 ```
 
 ### `<arm_sme.h>`
@@ -1061,13 +1030,10 @@ change or be extended in the future.
 
 `<arm_sme.h>` declares functions and defines intrinsics for SME
 and its extensions; see [SME language extensions and intrinsics](#sme-language-extensions-and-intrinsics)
-for details. The `__ARM_FEATURE_SME` macro should be tested before
-including the header:
+for details. 
 
 ``` c
-  #ifdef __ARM_FEATURE_SME
   #include <arm_sme.h>
-  #endif
 ```
 
 Including `<arm_sme.h>` also includes [`<arm_sve.h>`](#arm_sve.h).

--- a/main/acle.md
+++ b/main/acle.md
@@ -1006,7 +1006,9 @@ Neon and SVE vector types; see [NEON-SVE Bridge](#neon-sve-bridge)
 for details.
 
 ``` c
+  #ifdef __ARM_NEON_SVE_BRIDGE
   #include <arm_neon_sve_bridge.h>
+  #endif /* __ARM_NEON_SVE_BRIDGE */
 ```
 
 Including `<arm_neon_sve_bridge.h>` will also include


### PR DESCRIPTION
---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
