### PR TITLE
Limit the run of draftversion-check to the relevant branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
 
   draftversion-check:
     runs-on: ubuntu-latest
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: check correctness of draftversion fields
+    - name: Check correctness of draftversion fields
       run:  python ./tools/acle_draftversion_value_check.py .


### PR DESCRIPTION
The draftversion checker must run only in the main branch. This patch limits the run conditions to abide by this.