### PR TITLE
[FMV][AArch64] Add missing whitespace between comma separated features.

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -2715,8 +2715,8 @@ The following table lists the architectures feature mapping for AArch64
    | 106           | `FEAT_SM3`, `FEAT_SM4`   | sm4           | ```ID_AA64ISAR0_EL1.SM4 >= 0b0001```      |
    | 108           | `FEAT_RDM`               | rdm, rdma     | ```ID_AA64ISAR0_EL1.RDM >= 0b0001```      |
    | 110           | `FEAT_CRC32`             | crc           | ```ID_AA64ISAR0_EL1.CRC32 >= 0b0001```    |
-   | 130           | `FEAT_SHA1`,`FEAT_SHA256`| sha2          | ```ID_AA64ISAR0_EL1.SHA2 >= 0b0001```     |
-   | 140           | `FEAT_SHA512`,`FEAT_SHA3`| sha3          | ```ID_AA64ISAR0_EL1.SHA3 >= 0b0001```     |
+   | 130           | `FEAT_SHA1`, `FEAT_SHA256` | sha2        | ```ID_AA64ISAR0_EL1.SHA2 >= 0b0001```     |
+   | 140           | `FEAT_SHA512`, `FEAT_SHA3` | sha3        | ```ID_AA64ISAR0_EL1.SHA3 >= 0b0001```     |
    | 150           | `FEAT_AES`               | aes           | ```ID_AA64ISAR0_EL1.AES >= 0b0001```      |
    | 160           | `FEAT_PMULL`             | pmull         | ```ID_AA64ISAR0_EL1.AES >= 0b0010```      |
    | 170           | `FEAT_FP16`              | fp16          | ```ID_AA64PFR0_EL1.FP == 0b0001```        |
@@ -2746,7 +2746,7 @@ The following table lists the architectures feature mapping for AArch64
    | 390           | `FEAT_SVE_PMULL128`      | sve2-pmull128 | ```ID_AA64ZFR0_EL1.AES >= 0b0010```       |
    | 400           | `FEAT_SVE_BitPerm`       | sve2-bitperm  | ```ID_AA64ZFR0_EL1.BitPerm >= 0b0001```   |
    | 410           | `FEAT_SVE_SHA3`          | sve2-sha3     | ```ID_AA64ZFR0_EL1.SHA3 >= 0b0001```      |
-   | 420           | `FEAT_SM3`,`FEAT_SVE_SM4`| sve2-sm4      | ```ID_AA64ZFR0_EL1.SM4 >= 0b0001```       |
+   | 420           | `FEAT_SM3`, `FEAT_SVE_SM4` | sve2-sm4    | ```ID_AA64ZFR0_EL1.SM4 >= 0b0001```       |
    | 430           | `FEAT_SME`               | sme           | ```ID_AA64PFR1_EL1.SME >= 0b0001```       |
    | 440           | `FEAT_MTE`               | memtag        | ```ID_AA64PFR1_EL1.MTE >= 0b0001```       |
    | 450           | `FEAT_MTE2`              | memtag2       | ```ID_AA64PFR1_EL1.MTE >= 0b0010```       |


### PR DESCRIPTION
Minor change in the FMV table to improve readability.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
