### PR TITLE
Include SME attributes in the name mangling of types

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -10094,6 +10094,86 @@ an [`__arm_streaming`](#arm_streaming) type.
 See [Changing streaming mode locally](#changing-streaming-mode-locally)
 for more information.
 
+### C++ mangling of SME keywords
+
+SME keyword attributes which apply to function types must be included
+in the name mangling of the type, if the mangling would normally include
+the return type of the function.
+
+SME attributes are mangled in the same way as a template:
+
+``` c
+  template<typename, unsigned, unsigned, unsigned> __SME_ATTRS;
+```
+
+with the arguments:
+
+``` c
+  __SME_ATTRS<normal_function_type, streaming_mode, za_state, zt0_state>;
+```
+
+where:
+
+* normal_function_type is the function type without any SME attributes.
+
+* streaming_mode is an integer representing the streaming-mode of the function:
+
+  +------------------------+--------------------------+
+  | Interface Type         | Value                    |
+  +========================+==========================+
+  | Normal (default)       | 0                        |
+  +------------------------+--------------------------+
+  | Streaming Mode         | 1                        |
+  +------------------------+--------------------------+
+  | Streaming-Compatible   | 2                        |
+  +------------------------+--------------------------+
+
+* za_state is an integer representing the ZA state of the function:
+
+  +------------------------+--------------------------+
+  | Interface Type         | Value                    |
+  +========================+==========================+
+  | No ZA State (default)  | 0                        |
+  +------------------------+--------------------------+
+  | ZA-In                  | 1                        |
+  +------------------------+--------------------------+
+  | ZA-InOut               | 2                        |
+  +------------------------+--------------------------+
+  | ZA-Out                 | 3                        |
+  +------------------------+--------------------------+
+  | ZA-Preserved           | 4                        |
+  +------------------------+--------------------------+
+
+* zt0_state is an integer representing the ZT0 state of the function:
+
+  +------------------------+--------------------------+
+  | Interface Type         | Value                    |
+  +========================+==========================+
+  | No ZT0 State (default) | 0                        |
+  +------------------------+--------------------------+
+  | ZT0-In                 | 1                        |
+  +------------------------+--------------------------+
+  | ZT0-InOut              | 2                        |
+  +------------------------+--------------------------+
+  | ZT0-Out                | 3                        |
+  +------------------------+--------------------------+
+  | ZT0-Preserved          | 4                        |
+  +------------------------+--------------------------+
+
+For example:
+
+``` c
+
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj1ELj0ELj0EE
+  void f(svint8_t (*fn)() __arm_streaming) { fn(); }
+
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj2ELj2ELj0EE
+  void f(svint8_t (*fn)() __arm_streaming_compatible __arm_inout("za")) { fn(); }
+
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj0ELj0ELj3EE
+  void f(svint8_t (*fn)() __arm_out("zt0")) { fn(); }
+```
+
 ## SME types
 
 ### Predicate-as-counter

--- a/main/acle.md
+++ b/main/acle.md
@@ -424,6 +424,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Fixed SVE2.1 quadword gather load/scatter store intrinsics.
 * Removed unnecessary Zd argument from `svcvtnb_mf8[_f32_x2]_fpm`.
 * Fixed urls.
+* Changed name mangling of function types to include SME attributes.
 
 ### References
 
@@ -10118,52 +10119,35 @@ where:
 
 * streaming_mode is an integer representing the streaming-mode of the function:
 
-  +------------------------+--------------------------+
-  | Interface Type         | Value                    |
-  +========================+==========================+
-  | Normal (default)       | 0                        |
-  +------------------------+--------------------------+
-  | Streaming Mode         | 1                        |
-  +------------------------+--------------------------+
-  | Streaming-Compatible   | 2                        |
-  +------------------------+--------------------------+
+| **Interface Type**         | **Value**       |
+| -------------------------- | --------------- |
+| Normal (default)           | 0               |
+| Streaming Mode             | 1               |
+| Streaming-Compatible       | 2               |
 
 * za_state is an integer representing the ZA state of the function:
 
-  +------------------------+--------------------------+
-  | Interface Type         | Value                    |
-  +========================+==========================+
-  | No ZA State (default)  | 0                        |
-  +------------------------+--------------------------+
-  | ZA-In                  | 1                        |
-  +------------------------+--------------------------+
-  | ZA-InOut               | 2                        |
-  +------------------------+--------------------------+
-  | ZA-Out                 | 3                        |
-  +------------------------+--------------------------+
-  | ZA-Preserved           | 4                        |
-  +------------------------+--------------------------+
+| **Interface Type**         | **Value**       |
+| -------------------------- | --------------- |
+| No ZA State (default)      | 0               |
+| ZA-In                      | 1               |
+| ZA-InOut                   | 2               |
+| ZA-Out                     | 3               |
+| ZA-Preserved               | 4               |
 
 * zt0_state is an integer representing the ZT0 state of the function:
 
-  +------------------------+--------------------------+
-  | Interface Type         | Value                    |
-  +========================+==========================+
-  | No ZT0 State (default) | 0                        |
-  +------------------------+--------------------------+
-  | ZT0-In                 | 1                        |
-  +------------------------+--------------------------+
-  | ZT0-InOut              | 2                        |
-  +------------------------+--------------------------+
-  | ZT0-Out                | 3                        |
-  +------------------------+--------------------------+
-  | ZT0-Preserved          | 4                        |
-  +------------------------+--------------------------+
+| **Interface Type**         | **Value**       |
+| -------------------------- | --------------- |
+| No ZT0 State (default)     | 0               |
+| ZT0-In                     | 1               |
+| ZT0-InOut                  | 2               |
+| ZT0-Out                    | 3               |
+| ZT0-Preserved              | 4               |
 
 For example:
 
 ``` c
-
   // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj1ELj0ELj0EE
   void f(svint8_t (*fn)() __arm_streaming) { fn(); }
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -10104,7 +10104,7 @@ the return type of the function.
 SME attributes are mangled in the same way as a template:
 
 ``` c
-  template<typename, unsigned> __SME_ATTRS;
+  template<typename, uint64_t> __SME_ATTRS;
 ```
 
 with the arguments:
@@ -10117,25 +10117,23 @@ where:
 
 * normal_function_type is the function type without any SME attributes.
 
-* sme_state is an unsigned 64-bit integer representing the streaming mode, ZA state and ZT0 state of the function.
+* sme_state is an unsigned 64-bit integer representing the streaming and ZA properties of the function's interface.
 
 The bits are defined as follows:
 
-| **Bit** | **Value** | ** Interface Type **   |
-| ------- | --------- | ---------------------- |
-| 0       | 0x001     | Streaming Mode         |
-| 1       | 0x002     | Streaming-Compatible   |
-| 2       | 0x004     | ZA-In                  |
-| 3       | 0x008     | ZA-InOut               |
-| 4       | 0x010     | ZA-Out                 |
-| 5       | 0x020     | ZA-Preserved           |
-| 6       | 0x040     | ZT0-In                 |
-| 7       | 0x080     | ZT0-Out                |
-| 8       | 0x100     | ZT0-InOut              |
-| 9       | 0x200     | ZT0-Preserved          |
-| 10      | 0x400     | ZA State Agnostic      |
+| **Bit** | **Value** | ** Interface Type **           |
+| ------- | --------- | ------------------------------ |
+| 0       | 0x001     | __arm_streaming                |
+| 1       | 0x002     | __arm_streaming_compatible     |
+| 2       | 0x004     | __arm_agnostic("sme_za_state") |
+| 3       | 0x008     | __arm_in("za")                 |
+| 4       | 0x010     | __arm_out("za")                |
+| 5       | 0x020     | __arm_preserved("za")          |
+| 6       | 0x040     | __arm_in("zt0")                |
+| 7       | 0x080     | __arm_out("zt0")               |
+| 8       | 0x100     | __arm_preserved("zt0")         |
 
-The upper bits 11-63 are defined as leading zeroes, reserved for representing any future interface types.
+Bits 9-63 are defined to be zero by this revision of the ACLE and are reserved for future type attributes.
 
 For example:
 
@@ -10143,7 +10141,7 @@ For example:
   // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj1EE
   void f(svint8_t (*fn)() __arm_streaming) { fn(); }
 
-  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj10EE
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj26EE
   void f(svint8_t (*fn)() __arm_streaming_compatible __arm_inout("za")) { fn(); }
 
   // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj128EE

--- a/main/acle.md
+++ b/main/acle.md
@@ -10121,17 +10121,19 @@ where:
 
 The bits are defined as follows:
 
-| **Bit** | **Value** | ** Interface Type **           |
-| ------- | --------- | ------------------------------ |
-| 0       | 0x001     | __arm_streaming                |
-| 1       | 0x002     | __arm_streaming_compatible     |
-| 2       | 0x004     | __arm_agnostic("sme_za_state") |
-| 3       | 0x008     | __arm_in("za")                 |
-| 4       | 0x010     | __arm_out("za")                |
-| 5       | 0x020     | __arm_preserved("za")          |
-| 6       | 0x040     | __arm_in("zt0")                |
-| 7       | 0x080     | __arm_out("zt0")               |
-| 8       | 0x100     | __arm_preserved("zt0")         |
+| **Bits** | **Value** | ** Interface Type **           |
+| -------- | --------- | ------------------------------ |
+| 0        | 0b1       | __arm_streaming                |
+| 1        | 0b1       | __arm_streaming_compatible     |
+| 2        | 0b1       | __arm_agnostic("sme_za_state") |
+| 3-5      | 0b001     | __arm_in("za")                 |
+|          | 0b010     | __arm_out("za")                |
+|          | 0b011     | __arm_inout("za")              |
+|          | 0b100     | __arm_preserves("za")          |
+| 6-8      | 0b001     | __arm_in("zt0")                |
+|          | 0b010     | __arm_out("zt0")               |
+|          | 0b011     | __arm_inout("zt0")             |
+|          | 0b100     | __arm_preserves("zt0")         |
 
 Bits 9-63 are defined to be zero by this revision of the ACLE and are reserved for future type attributes.
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -10104,57 +10104,49 @@ the return type of the function.
 SME attributes are mangled in the same way as a template:
 
 ``` c
-  template<typename, unsigned, unsigned, unsigned> __SME_ATTRS;
+  template<typename, unsigned> __SME_ATTRS;
 ```
 
 with the arguments:
 
 ``` c
-  __SME_ATTRS<normal_function_type, streaming_mode, za_state, zt0_state>;
+  __SME_ATTRS<normal_function_type, sme_state>;
 ```
 
 where:
 
 * normal_function_type is the function type without any SME attributes.
 
-* streaming_mode is an integer representing the streaming-mode of the function:
+* sme_state is an unsigned 64-bit integer representing the streaming mode, ZA state and ZT0 state of the function.
 
-| **Interface Type**         | **Value**       |
-| -------------------------- | --------------- |
-| Normal (default)           | 0               |
-| Streaming Mode             | 1               |
-| Streaming-Compatible       | 2               |
+The bits are defined as follows:
 
-* za_state is an integer representing the ZA state of the function:
+| **Bit** | **Value** | ** Interface Type **   |
+| ------- | --------- | ---------------------- |
+| 0       | 0x001     | Streaming Mode         |
+| 1       | 0x002     | Streaming-Compatible   |
+| 2       | 0x004     | ZA-In                  |
+| 3       | 0x008     | ZA-InOut               |
+| 4       | 0x010     | ZA-Out                 |
+| 5       | 0x020     | ZA-Preserved           |
+| 6       | 0x040     | ZT0-In                 |
+| 7       | 0x080     | ZT0-Out                |
+| 8       | 0x100     | ZT0-InOut              |
+| 9       | 0x200     | ZT0-Preserved          |
+| 10      | 0x400     | ZA State Agnostic      |
 
-| **Interface Type**         | **Value**       |
-| -------------------------- | --------------- |
-| No ZA State (default)      | 0               |
-| ZA-In                      | 1               |
-| ZA-InOut                   | 2               |
-| ZA-Out                     | 3               |
-| ZA-Preserved               | 4               |
-
-* zt0_state is an integer representing the ZT0 state of the function:
-
-| **Interface Type**         | **Value**       |
-| -------------------------- | --------------- |
-| No ZT0 State (default)     | 0               |
-| ZT0-In                     | 1               |
-| ZT0-InOut                  | 2               |
-| ZT0-Out                    | 3               |
-| ZT0-Preserved              | 4               |
+The upper bits 11-63 are defined as leading zeroes, reserved for representing any future interface types.
 
 For example:
 
 ``` c
-  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj1ELj0ELj0EE
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj1EE
   void f(svint8_t (*fn)() __arm_streaming) { fn(); }
 
-  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj2ELj2ELj0EE
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj10EE
   void f(svint8_t (*fn)() __arm_streaming_compatible __arm_inout("za")) { fn(); }
 
-  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj0ELj0ELj3EE
+  // Mangled as _Z1fP11__SME_ATTRSIFu10__SVInt8_tvELj128EE
   void f(svint8_t (*fn)() __arm_out("zt0")) { fn(); }
 ```
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -10117,25 +10117,29 @@ where:
 
 * normal_function_type is the function type without any SME attributes.
 
-* sme_state is an unsigned 64-bit integer representing the streaming and ZA properties of the function's interface.
+* sme_state is an unsigned 64-bit integer representing the streaming and ZA
+  properties of the function's interface.
 
 The bits are defined as follows:
 
-| **Bits** | **Value** | ** Interface Type **           |
+| **Bits** | **Value** | **Interface Type**             |
 | -------- | --------- | ------------------------------ |
 | 0        | 0b1       | __arm_streaming                |
 | 1        | 0b1       | __arm_streaming_compatible     |
 | 2        | 0b1       | __arm_agnostic("sme_za_state") |
-| 3-5      | 0b001     | __arm_in("za")                 |
+| 3-5      | 0b000     | No ZA state (default)          |
+|          | 0b001     | __arm_in("za")                 |
 |          | 0b010     | __arm_out("za")                |
 |          | 0b011     | __arm_inout("za")              |
 |          | 0b100     | __arm_preserves("za")          |
-| 6-8      | 0b001     | __arm_in("zt0")                |
+| 6-8      | 0b000     | No ZT0 state (default)         |
+|          | 0b001     | __arm_in("zt0")                |
 |          | 0b010     | __arm_out("zt0")               |
 |          | 0b011     | __arm_inout("zt0")             |
 |          | 0b100     | __arm_preserves("zt0")         |
 
-Bits 9-63 are defined to be zero by this revision of the ACLE and are reserved for future type attributes.
+Bits 9-63 are defined to be zero by this revision of the ACLE and are reserved
+for future type attributes.
 
 For example:
 


### PR DESCRIPTION
This change extends the name mangling of types to include the SME streaming
and ZA interface. This will avoid naming conflicts which can currently arise such
as in the following example:

```
  void foo(void (*f)()) { f(); }
  void foo(void (*f)() __arm_streaming) { f(); }
```

Without this change, both functions 'foo' above will mangle to the same
name, despite the function pointers being different.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
