### PR TITLE
Change the FMV rules so target_clones default versions must be explicitly stated

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -445,6 +445,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added `svdot[_n_f16_mf8]_fpm` and `svdot[_n_f32_mf8]_fpm`.
 * Added Guarded Control Stack (GCS) at
   [**Beta**](#current-status-and-anticipated-changes) quality level.
+* Changed the Function Multi Versioning default version rules to be more explicit.
 
 ### References
 
@@ -2721,6 +2722,12 @@ The following attributes trigger the multi version code generation:
   type of the default version.
 * All the function versions must be declared at the translation
   unit in which the definition of the default version resides.
+* One `default` version of the function is required to be provided
+  in one of the translation units.
+  * Implicitly, as a definition without any attribute,
+  * as a function annotated with `target_version("default")`,
+  * or, as a function annotated with `target_clones(...)` where one
+    of the versions is `default`.
 
 The attribute `__attribute__((target_version("name")))` expresses the
 following:
@@ -2728,10 +2735,6 @@ following:
 * When applied to a function it becomes one of the versions.
 * Multiple function versions may exist in the same or in different
   translation units.
-* One `default` version of the function is required to be provided
-  in one of the translation units.
-  * Implicitly, without this attribute,
-  * or explicitly providing the `default` in the attribute.
 
 For example, the below is valid and 2 is used as the default
 value for `c` when calling the multiversioned function `f`.
@@ -2758,11 +2761,6 @@ following:
 
 * when applied to a function the compiler emits multiple versions
   based on the arguments.
-  * One of them is implicitly the `default`.
-  * If the `default` matches with another explicitly provided
-    version in the same translation unit, then the compiler can
-    emit only one function instead of the two. The explicitly
-    provided version shall be preferred.
 * If a name is not recognized the compiler should ignore it[^fmv-note-ignore].
 
 [^fmv-note-ignore]: The intention is to support the usecase of newer code if


### PR DESCRIPTION
This patch requires default versions in target_clones to be explicitly stated.

This makes it simple to determine where the dispatcher should be created across translation units, and resolves cases (such as below) where we can end up making multiple dispatchers.

```c++
// Translation unit 1
__attribute__ ((target_clone("dotprod, sve")))
int foo();

int foo() { return 1; }
```

```c
// Translation unit 2
__attribute__ ((target_clone("dotprod, sve")))
int foo() { return 2; }
```
With the previous specification, my understanding is, the second translation unit would implicitly add a default. Then there would be two implementations of defaults, and so two dispatchers would be created.


---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [X] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [X] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [X] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
