### PR TITLE
Add intrinsics for FEAT_SME_MOP4

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -11425,305 +11425,6 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
     __arm_streaming __arm_inout("za");
   ```
 
-#### FMOP4A (non-FP8), BFMOP4A, SMOP4A, UMOP4A
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                             svfloat32_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                             svfloat32x2_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                                      svfloat32_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                                      svfloat32x2_t zm)
-    __arm_streaming __arm_inout("za");
-  ```
-
-#### FMOP4S (non-FP8), BFMOP4S, SMOP4S, UMOP4S
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                             svfloat32_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                             svfloat32x2_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                                      svfloat32_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                                      svfloat32x2_t zm)
-    __arm_streaming __arm_inout("za");
-```
-
-#### SUMOP4A
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                           svuint8_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                           svuint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                                    svuint8__t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                                    svuint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-```
-
-#### SUMOP4S
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                           svuint8_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                           svuint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                                    svuint8__t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                                    svuint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-```
-
-#### USMOP4A
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                           svint8_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0 
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                           svint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                                    svint8__t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                                    svint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-```
-
-#### USMOP4S
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                           svint8_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0 
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                           svint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                                    svint8__t zm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0
-  // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                                    svint8x2_t zm)
-    __arm_streaming __arm_inout("za");
-```
-
-#### FMOP4A (FP8)
-
-``` c
-  // Only if __ARM_FEATURE_SME_MOP4 != 0 
-  // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa_za32[_f8](uint64_t tile, svmfloat8_t zn, 
-                        svmfloat8_t zm, fpm_t fpm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0 
-  // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa_za32[_f8](uint64_t tile, svmfloat8x2_t zn, 
-                        svmfloat8x2_t zm, fpm_t fpm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0 
-  // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8x2_t zn,
-                                 svmfloat8_t zm, fpm_t fpm)
-    __arm_streaming __arm_inout("za");
-
-  // Only if __ARM_FEATURE_SME_MOP4 != 0 
-  // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8_t zn,
-                                 svmfloat8x2_t zm, fpm_t fpm)
-    __arm_streaming __arm_inout("za");
-```
 
 #### BFMLA, BFMLS, FMLA, FMLS (single)
 
@@ -14035,6 +13736,288 @@ Multi-vector 8-bit floating-point multiply-add long.
     void svmopa_za32[_mf8]_m_fpm(uint64_t tile, svbool_t pn, svbool_t pm,
                                  svmfloat8_t zn, svmfloat8_t zm, fpm_t fpm)
                                  __arm_streaming __arm_inout("za");
+```
+
+### SME2 mop4 intrinsics
+
+The intrinsics in this section are defined by the header file
+[`<arm_sme.h>`](#arm_sme.h) when `__ARM_FEATURE_SME2` and
+`__ARM_FEATURE_SME_MOP4` are defined. Individual intrinsics may have
+additional target feature requirements.
+
+These intrinsics use an additional '_{1,2}x{1,2}' suffix in 
+non-overloaded names to indicate which vector argument is a vector register pair.
+
+#### FMOP4A (non-FP8), BFMOP4A, SMOP4A, UMOP4A
+
+``` c
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_1x1]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                             svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_2x2]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                             svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_2x1]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                                      svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_1x2]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                                      svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+  ```
+
+#### FMOP4S (non-FP8), BFMOP4S, SMOP4S, UMOP4S
+
+``` c
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_1x1]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                             svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_2x2]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                             svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_2x1]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                                      svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_1x2]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                                      svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### SUMOP4A
+
+``` c
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_1x1]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                           svuint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_2x2]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                           svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_2x1]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                                    svuint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_1x2]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                                    svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### SUMOP4S
+
+``` c
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_1x1]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                           svuint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_2x2]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                           svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_2x1]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                                    svuint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_1x2]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                                    svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### USMOP4A
+
+``` c
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_1x1]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                           svint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_2x2]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                           svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_2x1]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                                    svint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4a[_1x2]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                                    svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### USMOP4S
+
+``` c
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_1x1]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                           svint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_2x2]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                           svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_2x1]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                                    svint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmop4s[_1x2]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                                    svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### FMOP4A (FP8)
+
+``` c
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_1x1]_za32[_f8](uint64_t tile, svmfloat8_t zn, 
+                        svmfloat8_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_2x2]_za32[_f8](uint64_t tile, svmfloat8x2_t zn, 
+                        svmfloat8x2_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_2x1]_za32[_f8](uint64_t tile, svmfloat8x2_t zn,
+                                 svmfloat8_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_1x2]_za32[_f8](uint64_t tile, svmfloat8_t zn,
+                                 svmfloat8x2_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
 ```
 
 # M-profile Vector Extension (MVE) intrinsics

--- a/main/acle.md
+++ b/main/acle.md
@@ -10533,42 +10533,47 @@ ZA array vectors. The intrinsics model this in the following way:
     This level of detail is not exposed to the C/C++ intrinsics or types. It is
     left up to the compiler to choose the most optimal form.
 
-*   Intrinsic functions have a `_x2` or `_x4` suffix if the
-    function\'s widest type is a vector tuple of 2 or 4 data vectors
-    and the function operates purely on vectors, not on the matrix array or
-    tile slices. The suffix is only present on overloaded names if it cannot
-    be inferred from arguments.
+*   Intrinsic functions that operate on groups of SVE vectors, ZA tile slices or
+    ZA array vectors have one of the following suffixes added to them. These are 
+    selected according to the first matching rule (first suffix whose description 
+    matches the situation gets used):
 
-*   Intrinsic functions have a `_vg2` or `_vg4` suffix if the function
-    operates on groups of 2 or 4 ZA tile slices.  For example:
+  *   Intrinsic functions have a `_vg2` or `_vg4` suffix if the function
+      operates on groups of 2 or 4 ZA tile slices. For example:
 
-``` c
-    // Reads 2 consecutive horizontal tile slices from ZA into multi-vector.
-    svint8x2_t svread_hor_za8_s8_vg2(uint64_t tile, uint32_t slice)
-      __arm_streaming __arm_in("za");
-```
+  ``` c
+      // Reads 2 consecutive horizontal tile slices from ZA into multi-vector.
+      svint8x2_t svread_hor_za8_s8_vg2(uint64_t tile, uint32_t slice)
+        __arm_streaming __arm_in("za");
+  ```
 
-*   Intrinsic functions have a `_vg1x2`, `_vg1x4` suffix if the function
-    operates on 2 or 4 single-vector groups within the ZA array.
+  *   Intrinsic functions have a `_vg1x2`, `_vg1x4` suffix if the function
+      operates on 2 or 4 single-vector groups within the ZA array.
 
-*   Intrinsic functions have a `_vg2x1`, `_vg2x2`, `_vg2x4` suffix if
-    the function operates on 1, 2 or 4 double-vector groups within the ZA array.
+  *   Intrinsic functions have a `_vg2x1`, `_vg2x2`, `_vg2x4` suffix if
+      the function operates on 1, 2 or 4 double-vector groups within the ZA array.
 
-*   Intrinsic functions have a `_vg4x1`, `_vg4x2`, `_vg4x4` suffix if the
-    function operates on 1, 2 or 4 quad-vector groups within the ZA array.
-    For example:
+  *   Intrinsic functions have a `_vg4x1`, `_vg4x2`, `_vg4x4` suffix if the
+      function operates on 1, 2 or 4 quad-vector groups within the ZA array.
+      For example:
 
-``` c
-    // SMLAL intrinsic for 2 quad-vector groups.
-    void svmla_lane_za32[_s8]_vg4x2(uint32_t slice, svint8x2_t zn,
-                                    svint8_t zm, uint64_t imm_idx)
-      __arm_streaming __arm_inout("za");
-```
+  ``` c
+      // SMLAL intrinsic for 2 quad-vector groups.
+      void svmla_lane_za32[_s8]_vg4x2(uint32_t slice, svint8x2_t zn,
+                                      svint8_t zm, uint64_t imm_idx)
+        __arm_streaming __arm_inout("za");
+  ```
+
+  *   Intrinsic functions have a `_x2` or `_x4` suffix if the
+      function\'s widest type is a vector tuple of 2 or 4 data vectors. 
+      The suffix is only present on overloaded names if it cannot
+      be inferred from arguments.
+
 
 *   Intrinsic functions that take a multi-vector operand may have additional
     suffixes to distinguish them from other forms for the same intrinsic:
-    *   a `_single` suffix if they take one multi-vector operand and one
-        (single) vector operand.
+    *   a `_single` suffix if the last  vector operand is a single vector
+    *   a `_multi` suffix if the last vector operand is a multi-vector
     *   a `_lane` suffix if they take one multi-vector operand and one
         indexed vector operand with an immediate to specify the indexed
         elements.
@@ -11446,49 +11451,49 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16_x2]
+  //   _za32[_bf16_bf16_x2]
+  //   _za32[_s16_s16_x2]
+  //   _za32[_u16_u16_x2]
+  //   _za32[_s8_s8_x2]
+  //   _za32[_u8_u8_x2]
+  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
                              svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16_x2]
+  //   _za32[_bf16_bf16_x2]
+  //   _za32[_s16_s16_x2]
+  //   _za32[_u16_u16_x2]
+  //   _za32[_s8_s8_x2]
+  //   _za32[_u8_u8_x2]
+  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
                                       svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16_x2]
+  //   _za32[_bf16_bf16_x2]
+  //   _za32[_s16_s16_x2]
+  //   _za32[_u16_u16_x2]
+  //   _za32[_s8_s8_x2]
+  //   _za32[_u8_u8_x2]
+  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_multi]_za32[_f32_f32_x2](uint64_t tile, svfloat32_t zn, 
                                       svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
   ```
@@ -11514,49 +11519,49 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16_x2]
+  //   _za32[_bf16_bf16_x2]
+  //   _za32[_s16_s16_x2]
+  //   _za32[_u16_u16_x2]
+  //   _za32[_s8_s8_x2]
+  //   _za32[_u8_u8_x2]
+  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
                              svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16_x2]
+  //   _za32[_bf16_bf16_x2]
+  //   _za32[_s16_s16_x2]
+  //   _za32[_u16_u16_x2]
+  //   _za32[_s8_s8_x2]
+  //   _za32[_u8_u8_x2]
+  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
                                       svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16]
-  //   _za32[_bf16_bf16]
-  //   _za32[_s16_s16]
-  //   _za32[_u16_u16]
-  //   _za32[_s8_s8]
-  //   _za32[_u8_u8]
-  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16_x2]
+  //   _za32[_bf16_bf16_x2]
+  //   _za32[_s16_s16_x2]
+  //   _za32[_u16_u16_x2]
+  //   _za32[_s8_s8_x2]
+  //   _za32[_u8_u8_x2]
+  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_multi]_za32[_f32_f32_x2](uint64_t tile, svfloat32_t zn, 
                                       svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11573,22 +11578,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
                            svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
                                     svuint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_multi]_za32[_s8_u8_x2](uint64_t tile, svint8_t zn, 
                                     svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11605,22 +11610,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
                            svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
                                     svuint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_multi]_za32[_s8_u8_x2](uint64_t tile, svint8_t zn, 
                                     svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11637,22 +11642,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
                            svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
                                     svint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_multi]_za32[_u8_s8_x2](uint64_t tile, svuint8_t zn, 
                                     svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11669,22 +11674,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
                            svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
                                     svint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_multi]_za32[_u8_s8_x2](uint64_t tile, svuint8_t zn, 
                                     svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11694,33 +11699,33 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 ``` c
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa_za32[_f8](uint64_t tile, svmfloat8_t zn, 
+  //   _za16[_f8_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa_za32[_f8_f8](uint64_t tile, svmfloat8_t zn, 
                         svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa_za32[_f8](uint64_t tile, svmfloat8x2_t zn, 
+  //   _za16[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa_za32[_f8_f8_x2](uint64_t tile, svmfloat8x2_t zn, 
                         svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8x2_t zn,
+  //   _za16[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa[_single]_za32[_f8_f8_x2](uint64_t tile, svmfloat8x2_t zn,
                                  svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8_t zn,
+  //   _za16[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa[_multi]_za32[_f8_f8_x2](uint64_t tile, svmfloat8_t zn,
                                  svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```

--- a/main/acle.md
+++ b/main/acle.md
@@ -10533,47 +10533,42 @@ ZA array vectors. The intrinsics model this in the following way:
     This level of detail is not exposed to the C/C++ intrinsics or types. It is
     left up to the compiler to choose the most optimal form.
 
-*   Intrinsic functions that operate on groups of SVE vectors, ZA tile slices or
-    ZA array vectors have one of the following suffixes added to them. These are 
-    selected according to the first matching rule (first suffix whose description 
-    matches the situation gets used):
+*   Intrinsic functions have a `_x2` or `_x4` suffix if the
+    function\'s widest type is a vector tuple of 2 or 4 data vectors
+    and the function operates purely on vectors, not on the matrix array or
+    tile slices. The suffix is only present on overloaded names if it cannot
+    be inferred from arguments.
 
-  *   Intrinsic functions have a `_vg2` or `_vg4` suffix if the function
-      operates on groups of 2 or 4 ZA tile slices. For example:
+*   Intrinsic functions have a `_vg2` or `_vg4` suffix if the function
+    operates on groups of 2 or 4 ZA tile slices.  For example:
 
-  ``` c
-      // Reads 2 consecutive horizontal tile slices from ZA into multi-vector.
-      svint8x2_t svread_hor_za8_s8_vg2(uint64_t tile, uint32_t slice)
-        __arm_streaming __arm_in("za");
-  ```
+``` c
+    // Reads 2 consecutive horizontal tile slices from ZA into multi-vector.
+    svint8x2_t svread_hor_za8_s8_vg2(uint64_t tile, uint32_t slice)
+      __arm_streaming __arm_in("za");
+```
 
-  *   Intrinsic functions have a `_vg1x2`, `_vg1x4` suffix if the function
-      operates on 2 or 4 single-vector groups within the ZA array.
+*   Intrinsic functions have a `_vg1x2`, `_vg1x4` suffix if the function
+    operates on 2 or 4 single-vector groups within the ZA array.
 
-  *   Intrinsic functions have a `_vg2x1`, `_vg2x2`, `_vg2x4` suffix if
-      the function operates on 1, 2 or 4 double-vector groups within the ZA array.
+*   Intrinsic functions have a `_vg2x1`, `_vg2x2`, `_vg2x4` suffix if
+    the function operates on 1, 2 or 4 double-vector groups within the ZA array.
 
-  *   Intrinsic functions have a `_vg4x1`, `_vg4x2`, `_vg4x4` suffix if the
-      function operates on 1, 2 or 4 quad-vector groups within the ZA array.
-      For example:
+*   Intrinsic functions have a `_vg4x1`, `_vg4x2`, `_vg4x4` suffix if the
+    function operates on 1, 2 or 4 quad-vector groups within the ZA array.
+    For example:
 
-  ``` c
-      // SMLAL intrinsic for 2 quad-vector groups.
-      void svmla_lane_za32[_s8]_vg4x2(uint32_t slice, svint8x2_t zn,
-                                      svint8_t zm, uint64_t imm_idx)
-        __arm_streaming __arm_inout("za");
-  ```
-
-  *   Intrinsic functions have a `_x2` or `_x4` suffix if the
-      function\'s widest type is a vector tuple of 2 or 4 data vectors. 
-      The suffix is only present on overloaded names if it cannot
-      be inferred from arguments.
-
+``` c
+    // SMLAL intrinsic for 2 quad-vector groups.
+    void svmla_lane_za32[_s8]_vg4x2(uint32_t slice, svint8x2_t zn,
+                                    svint8_t zm, uint64_t imm_idx)
+      __arm_streaming __arm_inout("za");
+```
 
 *   Intrinsic functions that take a multi-vector operand may have additional
     suffixes to distinguish them from other forms for the same intrinsic:
-    *   a `_single` suffix if the last  vector operand is a single vector
-    *   a `_multi` suffix if the last vector operand is a multi-vector
+    *   a `_single` suffix if they take one multi-vector operand and one
+        (single) vector operand.
     *   a `_lane` suffix if they take one multi-vector operand and one
         indexed vector operand with an immediate to specify the indexed
         elements.
@@ -11451,49 +11446,49 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16_x2]
-  //   _za32[_bf16_bf16_x2]
-  //   _za32[_s16_s16_x2]
-  //   _za32[_u16_u16_x2]
-  //   _za32[_s8_s8_x2]
-  //   _za32[_u8_u8_x2]
-  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                              svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16_x2]
-  //   _za32[_bf16_bf16_x2]
-  //   _za32[_s16_s16_x2]
-  //   _za32[_u16_u16_x2]
-  //   _za32[_s8_s8_x2]
-  //   _za32[_u8_u8_x2]
-  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                                       svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16_x2]
-  //   _za32[_bf16_bf16_x2]
-  //   _za32[_s16_s16_x2]
-  //   _za32[_u16_u16_x2]
-  //   _za32[_s8_s8_x2]
-  //   _za32[_u8_u8_x2]
-  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_multi]_za32[_f32_f32_x2](uint64_t tile, svfloat32_t zn, 
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
                                       svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
   ```
@@ -11519,49 +11514,49 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16_x2]
-  //   _za32[_bf16_bf16_x2]
-  //   _za32[_s16_s16_x2]
-  //   _za32[_u16_u16_x2]
-  //   _za32[_s8_s8_x2]
-  //   _za32[_u8_u8_x2]
-  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                              svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16_x2]
-  //   _za32[_bf16_bf16_x2]
-  //   _za32[_s16_s16_x2]
-  //   _za32[_u16_u16_x2]
-  //   _za32[_s8_s8_x2]
-  //   _za32[_u8_u8_x2]
-  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_f32_f32_x2](uint64_t tile, svfloat32x2_t zn, 
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                                       svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za16[_f16_f16_x2] (only if __ARM_FEATURE_SME_F16F16 != 0)
-  //   _za16[_bf16_bf16_x2] (only if __ARM_FEATURE_SME_B16B16 != 0)
-  //   _za32[_f16_f16_x2]
-  //   _za32[_bf16_bf16_x2]
-  //   _za32[_s16_s16_x2]
-  //   _za32[_u16_u16_x2]
-  //   _za32[_s8_s8_x2]
-  //   _za32[_u8_u8_x2]
-  //   _za64[_f64_f64_x2] (only if __ARM_FEATURE_SME_F64F64 != 0)
-  //   _za64[_s16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_multi]_za32[_f32_f32_x2](uint64_t tile, svfloat32_t zn, 
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
                                       svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11578,22 +11573,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
                            svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
                                     svuint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_multi]_za32[_s8_u8_x2](uint64_t tile, svint8_t zn, 
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
                                     svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11610,22 +11605,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
                            svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_s8_u8_x2](uint64_t tile, svint8x2_t zn, 
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
                                     svuint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_s16_u16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_multi]_za32[_s8_u8_x2](uint64_t tile, svint8_t zn, 
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
                                     svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11642,22 +11637,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
                            svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_single]_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
                                     svint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmopa[_multi]_za32[_u8_s8_x2](uint64_t tile, svuint8_t zn, 
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
                                     svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11674,22 +11669,22 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
                            svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_single]_za32[_u8_s8_x2](uint64_t tile, svuint8x2_t zn, 
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
                                     svint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0
   // Variants are also available for:
-  //   _za64[_u16_s16_x2] (only if __ARM_FEATURE_SME_I16I64 != 0)
-  void svmops[_multi]_za32[_u8_s8_x2](uint64_t tile, svuint8_t zn, 
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
                                     svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
@@ -11699,33 +11694,33 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
 ``` c
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa_za32[_f8_f8](uint64_t tile, svmfloat8_t zn, 
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa_za32[_f8](uint64_t tile, svmfloat8_t zn, 
                         svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa_za32[_f8_f8_x2](uint64_t tile, svmfloat8x2_t zn, 
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa_za32[_f8](uint64_t tile, svmfloat8x2_t zn, 
                         svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa[_single]_za32[_f8_f8_x2](uint64_t tile, svmfloat8x2_t zn,
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8x2_t zn,
                                  svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_MOP4 != 0 
   // Variants are also available for:
-  //   _za16[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8_f8_x2] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmopa[_multi]_za32[_f8_f8_x2](uint64_t tile, svmfloat8_t zn,
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8_t zn,
                                  svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```

--- a/main/acle.md
+++ b/main/acle.md
@@ -444,7 +444,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added `svdot[_n_f16_mf8]_fpm` and `svdot[_n_f32_mf8]_fpm`.
 * Added Guarded Control Stack (GCS) at
   [**Beta**](#current-status-and-anticipated-changes) quality level.
-*  Added [**Beta**](#current-status-and-anticipated-changes) support 
+*  Added [**Alpha**](#current-status-and-anticipated-changes) support 
    for quarter-tile outer product intrinsics.
 
 ### References
@@ -11425,7 +11425,6 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
     __arm_streaming __arm_inout("za");
   ```
 
-
 #### BFMLA, BFMLS, FMLA, FMLS (single)
 
 Multi-vector floating-point fused multiply-add/subtract
@@ -13745,7 +13744,7 @@ The intrinsics in this section are defined by the header file
 `__ARM_FEATURE_SME_MOP4` are defined. Individual intrinsics may have
 additional target feature requirements.
 
-These intrinsics use an additional '_{1,2}x{1,2}' suffix in 
+These intrinsics have an additional '_{1,2}x{1,2}' suffix in 
 non-overloaded names to indicate which vector argument is a vector register pair.
 
 #### FMOP4A (non-FP8), BFMOP4A, SMOP4A, UMOP4A
@@ -13762,6 +13761,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x1]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
                              svfloat32_t zm)
     __arm_streaming __arm_inout("za");
@@ -13777,6 +13777,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x2]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                              svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
@@ -13792,6 +13793,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x1]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                                       svfloat32_t zm)
     __arm_streaming __arm_inout("za");
@@ -13807,6 +13809,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x2]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
                                       svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
@@ -13826,6 +13829,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x1]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
                              svfloat32_t zm)
     __arm_streaming __arm_inout("za");
@@ -13840,6 +13844,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_s8_s8]
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x2]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                              svfloat32x2_t zm)
@@ -13856,6 +13861,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x1]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
                                       svfloat32_t zm)
     __arm_streaming __arm_inout("za");
@@ -13871,6 +13877,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za32[_u8_u8]
   //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x2]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
                                       svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
@@ -13991,31 +13998,31 @@ non-overloaded names to indicate which vector argument is a vector register pair
 #### FMOP4A (FP8)
 
 ``` c
-  // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmop4a[_1x1]_za32[_f8](uint64_t tile, svmfloat8_t zn, 
+    // Variants are also available for:
+  //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_1x1]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8_t zn, 
                         svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmop4a[_2x2]_za32[_f8](uint64_t tile, svmfloat8x2_t zn, 
+  //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_2x2]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn, 
                         svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmop4a[_2x1]_za32[_f8](uint64_t tile, svmfloat8x2_t zn,
+  //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_2x1]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn,
                                  svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
-  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
-  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
-  void svmop4a[_1x2]_za32[_f8](uint64_t tile, svmfloat8_t zn,
+  //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmop4a[_1x2]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8_t zn,
                                  svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```

--- a/main/acle.md
+++ b/main/acle.md
@@ -444,6 +444,8 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added `svdot[_n_f16_mf8]_fpm` and `svdot[_n_f32_mf8]_fpm`.
 * Added Guarded Control Stack (GCS) at
   [**Beta**](#current-status-and-anticipated-changes) quality level.
+*  Added [**Beta**](#current-status-and-anticipated-changes) support 
+   for quarter-tile outer product intrinsics.
 
 ### References
 
@@ -2370,6 +2372,17 @@ support for the SME double precision floating-point outer product
 (FEAT_SME_F64F64) instructions and if their associated intrinsics are
 available. This implies that `__ARM_FEATURE_SME` is nonzero.
 
+#### Quarter-tile outer product intrinsics
+
+The specification for SME is in
+[**Beta** state](#current-status-and-anticipated-changes) and may change or be
+extended in the future.
+
+`__ARM_FEATURE_SME_MOP4` is defined to `1` if there is hardware
+support for the SME quarter-tile outer product(FEAT_SME_MOP4) 
+instructions and if their associated intrinsics are
+available. This implies that `__ARM_FEATURE_SME2` is nonzero.
+
 ## Floating-point model
 
 These macros test the floating-point model implemented by the compiler
@@ -2566,6 +2579,7 @@ be found in [[BA]](#BA).
 | [`__ARM_FEATURE_SME_F8F16`](#modal-8-bit-floating-point-extensions)                                                                                     | Modal 8-bit floating-point extensions                                                              | 1           |
 | [`__ARM_FEATURE_SME_F8F32`](#modal-8-bit-floating-point-extensions)                                                                                     | Modal 8-bit floating-point extensions                                                              | 1           |
 | [`__ARM_FEATURE_SME_I16I64`](#16-bit-to-64-bit-integer-widening-outer-product-intrinsics)                                                               | 16-bit to 64-bit integer widening outer product intrinsics (FEAT_SME_I16I64)                       | 1           |
+| [`__ARM_FEATURE_SME_MOP4`](#quarter-tile-outer-product-intrinsics)                                                               | quarter-tile outer product intrinsics (FEAT_SME_MOP4)                       | 1           |
 | [`__ARM_FEATURE_SME_LOCALLY_STREAMING`](#scalable-matrix-extension-sme)                                                                                 | Support for the `arm_locally_streaming` attribute                                                  | 1           |
 | [`__ARM_FEATURE_SME_LUTv2`](#lookup-table-extensions)                                                                                                   | Lookup table extensions (FEAT_SME_LUTv2)                                                           | 1           |
 | [`__ARM_FEATURE_SSVE_FP8DOT2`](#modal-8-bit-floating-point-extensions)                                                                                  | Modal 8-bit floating-point extensions                                                              | 1           |
@@ -11410,6 +11424,306 @@ Bitwise exclusive NOR population count outer product and accumulate/subtract
                             svuint32_t zn, svuint32_t zm)
     __arm_streaming __arm_inout("za");
   ```
+
+#### FMOP4A (non-FP8), BFMOP4A, SMOP4A, UMOP4A
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                             svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                             svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                                      svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                                      svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+  ```
+
+#### FMOP4S (non-FP8), BFMOP4S, SMOP4S, UMOP4S
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                             svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                             svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
+                                      svfloat32_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za16[_f16_f16] (only if __ARM_FEATURE_SME_F16F16 != 0)
+  //   _za16[_bf16_bf16] (only if __ARM_FEATURE_SME_B16B16 != 0)
+  //   _za32[_f16_f16]
+  //   _za32[_bf16_bf16]
+  //   _za32[_s16_s16]
+  //   _za32[_u16_u16]
+  //   _za32[_s8_s8]
+  //   _za32[_u8_u8]
+  //   _za64[_f64_f64] (only if __ARM_FEATURE_SME_F64F64 != 0)
+  //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
+                                      svfloat32x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### SUMOP4A
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                           svuint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                           svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                                    svuint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                                    svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### SUMOP4S
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                           svuint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                           svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
+                                    svuint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
+                                    svuint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### USMOP4A
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                           svint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0 
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                           svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                                    svint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmopa[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                                    svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### USMOP4S
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                           svint8_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0 
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                           svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
+                                    svint8__t zm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0
+  // Variants are also available for:
+  //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
+  void svmops[_single]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
+                                    svint8x2_t zm)
+    __arm_streaming __arm_inout("za");
+```
+
+#### FMOP4A (FP8)
+
+``` c
+  // Only if __ARM_FEATURE_SME_MOP4 != 0 
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa_za32[_f8](uint64_t tile, svmfloat8_t zn, 
+                        svmfloat8_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0 
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa_za32[_f8](uint64_t tile, svmfloat8x2_t zn, 
+                        svmfloat8x2_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0 
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8x2_t zn,
+                                 svmfloat8_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+
+  // Only if __ARM_FEATURE_SME_MOP4 != 0 
+  // Variants are also available for:
+  //   _za16[_f8] (only if __ARM_FEATURE_SME_F8F16 != 0)
+  //   _za32[_f8] (only if __ARM_FEATURE_SME_F8F32 != 0)
+  void svmopa[_single]_za32[_f8](uint64_t tile, svmfloat8_t zn,
+                                 svmfloat8x2_t zm, fpm_t fpm)
+    __arm_streaming __arm_inout("za");
+```
 
 #### BFMLA, BFMLS, FMLA, FMLS (single)
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -2375,7 +2375,7 @@ available. This implies that `__ARM_FEATURE_SME` is nonzero.
 #### Quarter-tile outer product intrinsics
 
 The specification for SME is in
-[**Beta** state](#current-status-and-anticipated-changes) and may change or be
+[**Alpha** state](#current-status-and-anticipated-changes) and may change or be
 extended in the future.
 
 `__ARM_FEATURE_SME_MOP4` is defined to `1` if there is hardware

--- a/main/acle.md
+++ b/main/acle.md
@@ -444,8 +444,8 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added `svdot[_n_f16_mf8]_fpm` and `svdot[_n_f32_mf8]_fpm`.
 * Added Guarded Control Stack (GCS) at
   [**Beta**](#current-status-and-anticipated-changes) quality level.
-*  Added [**Alpha**](#current-status-and-anticipated-changes) support 
-   for quarter-tile outer product intrinsics.
+* Added [**Alpha**](#current-status-and-anticipated-changes) support 
+  for quarter-tile outer product intrinsics.
 
 ### References
 
@@ -2579,7 +2579,7 @@ be found in [[BA]](#BA).
 | [`__ARM_FEATURE_SME_F8F16`](#modal-8-bit-floating-point-extensions)                                                                                     | Modal 8-bit floating-point extensions                                                              | 1           |
 | [`__ARM_FEATURE_SME_F8F32`](#modal-8-bit-floating-point-extensions)                                                                                     | Modal 8-bit floating-point extensions                                                              | 1           |
 | [`__ARM_FEATURE_SME_I16I64`](#16-bit-to-64-bit-integer-widening-outer-product-intrinsics)                                                               | 16-bit to 64-bit integer widening outer product intrinsics (FEAT_SME_I16I64)                       | 1           |
-| [`__ARM_FEATURE_SME_MOP4`](#quarter-tile-outer-product-intrinsics)                                                               | quarter-tile outer product intrinsics (FEAT_SME_MOP4)                       | 1           |
+| [`__ARM_FEATURE_SME_MOP4`](#quarter-tile-outer-product-intrinsics)                                                                                      | quarter-tile outer product intrinsics (FEAT_SME_MOP4)                                              | 1           |
 | [`__ARM_FEATURE_SME_LOCALLY_STREAMING`](#scalable-matrix-extension-sme)                                                                                 | Support for the `arm_locally_streaming` attribute                                                  | 1           |
 | [`__ARM_FEATURE_SME_LUTv2`](#lookup-table-extensions)                                                                                                   | Lookup table extensions (FEAT_SME_LUTv2)                                                           | 1           |
 | [`__ARM_FEATURE_SSVE_FP8DOT2`](#modal-8-bit-floating-point-extensions)                                                                                  | Modal 8-bit floating-point extensions                                                              | 1           |


### PR DESCRIPTION
---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [X ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ X] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
