### PR TITLE
Fix incorrect tmop fp8 definition and formatting of tmop and mop4 intrinsics

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -10920,7 +10920,7 @@ Replacing `_hor` with `_ver` gives the associated vertical forms.
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_TMOP != 0 && __ARM_FEATURE_SME_F8F32 != 0
-  void svtmopa_lane_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn,svmfloat8_t zm, 
+  void svtmopa_lane_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn, svmfloat8_t zm, 
                               svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```

--- a/main/acle.md
+++ b/main/acle.md
@@ -13948,7 +13948,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x2]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                                      svfloat32x2_t zm)
+                                    svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -13998,13 +13998,13 @@ non-overloaded names to indicate which vector argument is a vector register pair
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x1]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                                  svuint8__t zm)
+                                  svuint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x2]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                                  vuint8x2_t zm)
+                                  svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -14054,7 +14054,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x1]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                                  svint8__t zm)
+                                  svint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:

--- a/main/acle.md
+++ b/main/acle.md
@@ -10911,17 +10911,17 @@ Replacing `_hor` with `_ver` gives the associated vertical forms.
   //   _za32[_s8_s8]
   //   _za32[_u8_u8]
   void svtmopa_lane_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, svfloat32_t zm, 
-                              svuint8_t zk, uint64_t imm_idx)
+                                   svuint8_t zk, uint64_t imm_idx)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_TMOP != 0 && __ARM_FEATURE_SME_F8F16 != 0
   void svtmopa_lane_za16[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn, svmfloat8_t zm, 
-                            svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
+                                       svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_TMOP != 0 && __ARM_FEATURE_SME_F8F32 != 0
   void svtmopa_lane_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn, svmfloat8_t zm, 
-                              svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
+                                       svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -10930,12 +10930,12 @@ Replacing `_hor` with `_ver` gives the associated vertical forms.
 ``` c
   // Only if __ARM_FEATURE_SME_TMOP != 0
   void svtmopa_lane_za32[_s8_u8](uint64_t tile, svint8x2_t zn, svuint8_t zm, 
-                            svuint8_t zk, uint64_t imm_idx)
+                                 svuint8_t zk, uint64_t imm_idx)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_TMOP != 0
   void svtmopa_lane_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, svint8_t zm, 
-                            svuint8_t zk, uint64_t imm_idx)
+                                 svuint8_t zk, uint64_t imm_idx)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -13832,7 +13832,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x1]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                             svfloat32_t zm)
+                                    svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
@@ -13848,7 +13848,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x2]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                             svfloat32x2_t zm)
+                                    svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
@@ -13864,7 +13864,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x1]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                                      svfloat32_t zm)
+                                    svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
@@ -13880,7 +13880,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x2]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                                      svfloat32x2_t zm)
+                                    svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
   ```
 
@@ -13900,7 +13900,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x1]_za32[_f32_f32](uint64_t tile, svfloat32_t zn, 
-                             svfloat32_t zm)
+                                    svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
@@ -13916,7 +13916,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x2]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                             svfloat32x2_t zm)
+                                    svfloat32x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
@@ -13932,7 +13932,7 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za64[_s16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   //   _za64[_u16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x1]_za32[_f32_f32](uint64_t tile, svfloat32x2_t zn, 
-                                      svfloat32_t zm)
+                                    svfloat32_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
@@ -13958,25 +13958,25 @@ non-overloaded names to indicate which vector argument is a vector register pair
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x1]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                           svuint8_t zm)
+                                  svuint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x2]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                           svuint8x2_t zm)
+                                  svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x1]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                                    svuint8__t zm)
+                                  svuint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x2]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                                    svuint8x2_t zm)
+                                  svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -13986,25 +13986,25 @@ non-overloaded names to indicate which vector argument is a vector register pair
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x1]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                           svuint8_t zm)
+                                  svuint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x2]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                           svuint8x2_t zm)
+                                  svuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x1]_za32[_s8_u8](uint64_t tile, svint8x2_t zn, 
-                                    svuint8__t zm)
+                                  svuint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_s16_u16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x2]_za32[_s8_u8](uint64_t tile, svint8_t zn, 
-                                    svuint8x2_t zm)
+                                  vuint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -14014,25 +14014,25 @@ non-overloaded names to indicate which vector argument is a vector register pair
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x1]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                           svint8_t zm)
+                                  svint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x2]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                           svint8x2_t zm)
+                                  svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_2x1]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                                    svint8__t zm)
+                                  svint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4a[_1x2]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                                    svint8x2_t zm)
+                                  svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -14042,25 +14042,25 @@ non-overloaded names to indicate which vector argument is a vector register pair
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x1]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                           svint8_t zm)
+                                  svint8_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x2]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                           svint8x2_t zm)
+                                  svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_2x1]_za32[_u8_s8](uint64_t tile, svuint8x2_t zn, 
-                                    svint8__t zm)
+                                  svint8__t zm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za64[_u16_s16] (only if __ARM_FEATURE_SME_I16I64 != 0)
   void svmop4s[_1x2]_za32[_u8_s8](uint64_t tile, svuint8_t zn, 
-                                    svint8x2_t zm)
+                                  svint8x2_t zm)
     __arm_streaming __arm_inout("za");
 ```
 
@@ -14071,28 +14071,28 @@ non-overloaded names to indicate which vector argument is a vector register pair
   //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
   //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
   void svmop4a[_1x1]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8_t zn, 
-                        svmfloat8_t zm, fpm_t fpm)
+                                        svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
   //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
   void svmop4a[_2x2]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn, 
-                        svmfloat8x2_t zm, fpm_t fpm)
+                                        svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
   //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
   void svmop4a[_2x1]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn,
-                                 svmfloat8_t zm, fpm_t fpm)
+                                        svmfloat8_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Variants are also available for:
   //   _za16[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F16 != 0)
   //   _za32[_mf8_mf8] (only if __ARM_FEATURE_SME_F8F32 != 0)
   void svmop4a[_1x2]_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8_t zn,
-                                 svmfloat8x2_t zm, fpm_t fpm)
+                                        svmfloat8x2_t zm, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -10915,12 +10915,12 @@ Replacing `_hor` with `_ver` gives the associated vertical forms.
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_TMOP != 0 && __ARM_FEATURE_SME_F8F16 != 0
-  void svtmopa_lane_za16[_mf8_mf8]_fpm(uint64_t tile, svfloat32x2_t zn, svfloat32_t zm, 
+  void svtmopa_lane_za16[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn, svmfloat8_t zm, 
                             svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 
   // Only if __ARM_FEATURE_SME_TMOP != 0 && __ARM_FEATURE_SME_F8F32 != 0
-  void svtmopa_lane_za32[_mf8_mf8]_fpm(uint64_t tile, svfloat32x2_t zn, svfloat32_t zm, 
+  void svtmopa_lane_za32[_mf8_mf8]_fpm(uint64_t tile, svmfloat8x2_t zn,svmfloat8_t zm, 
                               svuint8_t zk, uint64_t imm_idx, fpm_t fpm)
     __arm_streaming __arm_inout("za");
 ```


### PR DESCRIPTION
---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
