### PR TITLE
Add FMV priority syntax

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -2843,14 +2843,14 @@ For example, it can be implemented as:
 
 ### Target version strings
 
-A target version string is of the following form:
+A target version string has the following form:
 
 ```
 <target version string>    := 'default'
                             | <version string>
-<version string>           := <priority string> ';' <arch strings>
+<version string>           :=  <arch strings> ';' <priority string>
                             | <arch strings>
-<priority string>          := 'priority=[1-31]'
+<priority string>          := 'priority=[1-255]'
 <arch strings>             := <arch strings> '+' arch extension
                             | arch extension
 ```
@@ -2863,8 +2863,8 @@ Valid string examples are given below
 default
 dotprod
 dotprod+flagm
-priority=5;sve
-priority=23;sve2+sme2
+sve;priority=5
+sve2+sme2;priority=23
 ```
 
 ### Name mangling
@@ -2883,7 +2883,7 @@ the [[cxxabi]](#cxxabi), and it is defined as follows:
 <vendor specific suffix> := `_` followed by token obtained from the tables below and prefixed with `M`
 ```
 
-Note, priority values do not affect mangling.
+Priority values do not affect mangling.
 
 If multiple features are requested then those shall be appended in lexicographic
 order and prefixed with `M`. The mangled name shall contain a unique set of


### PR DESCRIPTION
Hi all,

This is a PR to implement option 3 of #403 proposed by @labrinea .

It adds the proposed syntax, with higher priority values taking precedence.

Happy to modify wording if needed.

---

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [X] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
