### PR TITLE
Restrict FMV to not be combined with other mangling/cloning extensions

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -465,6 +465,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 
 * Added feature test macro for FEAT_SSVE_FEXPA.
 * Added feature test macro for FEAT_CSSC.
+* Added restrictions of Function Multi Versioning's use with other extensions.
 
 ### References
 
@@ -2788,6 +2789,8 @@ The following attributes trigger the multi version code generation:
   * as a function annotated with `target_version("default")`,
   * or, as a function annotated with `target_clones(...)` where one
     of the versions is `default`.
+* Using any C/C++ extensions or attributes that affect function name mangling,
+  or that clone functions alongside Function Multi Versioning is not supported.
 
 The attribute `__attribute__((target_version("<target version string>")))` expresses the
 following:


### PR DESCRIPTION
Function Multi Versioning should not be used alongside any C/C++ extensions
or attributes that affect function name mangling, or that clone functions.