### PR TITLE
Set draftversion to true

### DIFF
--- a/cmse/cmse.md
+++ b/cmse/cmse.md
@@ -5,7 +5,7 @@ date-of-issue: 21 June 2024
 set-quote-highlight: true
 # LaTeX specific variables
 copyright-text: Copyright 2019, 2021-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>.
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/main/acle.md
+++ b/main/acle.md
@@ -4,7 +4,7 @@ version: 2025Q3
 date-of-issue: 14 November 2025
 # LaTeX specific variables
 copyright-text: "Copyright: see section \\texorpdfstring{\\nameref{copyright}}{Copyright}."
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/morello/morello.md
+++ b/morello/morello.md
@@ -4,7 +4,7 @@ version: 02alpha
 date-of-issue: 11 January 2022
 # LaTeX specific variables
 copyright-text: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/mve_intrinsics/mve.md
+++ b/mve_intrinsics/mve.md
@@ -5,7 +5,7 @@ date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/mve_intrinsics/mve.template.md
+++ b/mve_intrinsics/mve.template.md
@@ -5,7 +5,7 @@ date-of-issue: 11 January 2022
 # LaTeX specific variables
 landscape: true
 copyright-text: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>.
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/neon_intrinsics/advsimd.md
+++ b/neon_intrinsics/advsimd.md
@@ -5,7 +5,7 @@ date-of-issue: 06 June 2025
 # LaTeX specific variables
 landscape: true
 copyright-text: "Copyright: see section \\texorpdfstring{\\nameref{copyright}}{Copyright}."
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true

--- a/neon_intrinsics/advsimd.template.md
+++ b/neon_intrinsics/advsimd.template.md
@@ -5,7 +5,7 @@ date-of-issue: 06 June 2025
 # LaTeX specific variables
 landscape: true
 copyright-text: "Copyright: see section \\texorpdfstring{{\\nameref{{copyright}}}}{{Copyright}}."
-draftversion: false
+draftversion: true
 # Jekyll specific variables
 header_counter: true
 toc: true


### PR DESCRIPTION
draftversion is set to true by the first patch after a release, but then that patch gets polluted with unrelated changes. (see #424)

This standalone patch restores draftversion to true, so that other interesting patches do not have to worry about it.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [X] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [X] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [X] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [X] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [X] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [X] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
