### PR TITLE
Add FEAT_CMH support

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -488,7 +488,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added [**Alpha**](#current-status-and-anticipated-changes) support
   for Brain 16-bit floating-point vector multiplication intrinsics.
 * Redesigned atomic store with hints intrinsics.
-
+* Added support for producer-consumer data placement hints. [**Alpha** state]
 ### References
 
 This document refers to the following documents.
@@ -1849,7 +1849,7 @@ execution state. Intrinsics for the use of these instructions are specified in
 data placement hints (FEAT_PCDPHINT) instructions and their associated
 intrinsics are available on the target.
 
-### Contention Management hints
+### Contention Management hints [**Alpha** state]
 
 `__ARM_FEATURE_CMH` is defined to `1` if the Contention Management hints
 (FEAT_CMH) instructions and their associated intrinsics are available on the target.
@@ -4991,58 +4991,40 @@ target. The following hint values are defined:
 | ---------------- | --------- | -------------------------- | --------------------------------------------------------------------------------- |
 | HINT_STSHH_KEEP  | 0         | `__ARM_FEATURE_PCDPHINT`   | Requests retention of the updated location in the local cache of the updating PE. |
 | HINT_STSHH_STRM  | 1         | `__ARM_FEATURE_PCDPHINT`   | Requests that the updated location not be retained in the local cache of the updating PE. |
+| HINT_STCPH       | 2         | `__ARM_FEATURE_CMH`        | Ensures that the memory write effect of the next instruction occurs before any other effects from other threads.|
+| HINT_SHUH        | 3         | `__ARM_FEATURE_CMH`        | Informs that the next instruction generates an effect in a location that one or more other threads of execution are likely to subsequently update. |
+| HINT_SHUH_PH     | 4         | `__ARM_FEATURE_CMH`        | PH adds the effects of STCPH to SHUH. |
 
-## Atomic store with CMH intrinsics
-
-These intrinsics provide an atomic store, which will
-make use of the `STCPH` or `SHUH` hint instructions immediately followed by the
-associated store instruction. These intrinsics are type generic and 
-support scalar types from 8-64 bits and are available when
-`__ARM_FEATURE_CMH` is defined.
-
-To access these intrinsics, `<arm_acle.h>` should be included.
-
-``` c
-  void __arm_atomic_store_with_stcph(type *ptr, type data, int memory_order);
-  void __arm_atomic_store_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
-```
-
-The first argument in these intrinsics is a pointer `ptr` which is the location to store to.
-The second argument `data` is the data which is to be stored.
-The third argument `mem` can be one of 3 memory ordering variables supported by atomic_store:
-__ATOMIC_RELAXED, __ATOMIC_SEQ_CST, and __ATOMIC_RELEASE.
-The fourth argument `priority_hint` can be either 0 or 1. If set to 1 then if the next instruction in program order generates
-an Explicit Memory Write Effect, then there is a performance benefit if that Explicit Memory Write Effect
-is sequenced before Memory Effects from other threads of execution in the coherence order to the same
-location.
-
-## Atomic fetch with CMH intrinsics
+## Atomic fetch with hints intrinsics [**Alpha** state]
 
 These intrinsics provide some atomic fetch operations, which will
-make use of the `SHUH` hint instruction immediately followed by the
+make use of hint instructions immediately followed by the
 associated fetch instructions. These intrinsics are type generic and 
-support scalar types from 8-64 bits and are available when
-`__ARM_FEATURE_CMH` is defined.
+supports scalar integral and floating-point types of 8, 16, 32, and 64 bits.
 
 To access these intrinsics, `<arm_acle.h>` should be included.
 
 ``` c
-  type __arm_atomic_fetch_add_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
-  type __arm_atomic_fetch_sub_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
-  type __arm_atomic_fetch_and_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
-  type __arm_atomic_fetch_xor_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
-  type __arm_atomic_fetch_or_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
-  type __arm_atomic_fetch_nand_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+  type __arm_atomic_fetch_add_with_hint(type *ptr, type data, int memory_order, int hint);
+  type __arm_atomic_fetch_sub_with_hint(type *ptr, type data, int memory_order, int hint);
+  type __arm_atomic_fetch_and_with_hint(type *ptr, type data, int memory_order, int hint);
+  type __arm_atomic_fetch_xor_with_hint(type *ptr, type data, int memory_order, int hint);
+  type __arm_atomic_fetch_or_with_hint(type *ptr, type data, int memory_order, int hint);
 ```
 
 The first argument in these intrinsic is a pointer `ptr` which is the location to store to.
 The second argument `data` is the data which is to be stored.
 The third argument `mem` can be one of 6 memory ordering variables supported by atomic_fetch:
 __ATOMIC_RELAXED, __ATOMIC_SEQ_CST, __ATOMIC_ACQUIRE, __ATOMIC_CONSUME, __ATOMIC_ACQ_REL and __ATOMIC_RELEASE.
-The fourth argument `priority_hint` can be either 0 or 1. If set to 1 then if the next instruction in program order generates
-an Explicit Memory Write Effect, then there is a performance benefit if that Explicit Memory Write Effect
-is sequenced before Memory Effects from other threads of execution in the coherence order to the same
-location.
+
+The fourth argument `hint` selects the requested hint. The set of valid
+hint values depends on the architectural features supported by the
+target. The following hint values are defined:
+
+| **Hint**         | **Value** | **Feature**                | **Summary**                                                                       |
+| ---------------- | --------- | -------------------------- | --------------------------------------------------------------------------------- |
+| HINT_SHUH        | 0         | `__ARM_FEATURE_CMH`        | Informs that the next instruction generates an effect in a location that one or more other threads of execution are likely to subsequently update. |
+| HINT_SHUH_PH     | 1         | `__ARM_FEATURE_CMH`        | PH adds the effects of STCPH to SHUH. |
 
 # Custom Datapath Extension
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -1848,6 +1848,11 @@ execution state. Intrinsics for the use of these instructions are specified in
 data placement hints (FEAT_PCDPHINT) instructions and their associated
 intrinsics are available on the target.
 
+### Contention Management hints
+
+`__ARM_FEATURE_CMH` is defined to `1` if the Contention Management hints
+(FEAT_CMH) instructions and their associated intrinsics are available on the target.
+
 ## Floating-point and vector hardware
 
 ### Hardware floating point
@@ -2654,6 +2659,7 @@ be found in [[BA]](#BA).
 | [`__ARM_FEATURE_CDE`](#custom-datapath-extension)                                                                                                       | Custom Datapath Extension                                                                          | 0x01        |
 | [`__ARM_FEATURE_CDE_COPROC`](#custom-datapath-extension)                                                                                                | Custom Datapath Extension                                                                          | 0xf         |
 | [`__ARM_FEATURE_CLZ`](#clz)                                                                                                                             | CLZ instruction                                                                                    | 1           |
+| [`__ARM_FEATURE_CMH`](#contention-management-hints)                                                                                                     | Contention management hints                                                                        | 1           |
 | [`__ARM_FEATURE_COMPLEX`](#complex-number-intrinsics)                                                                                                   | Armv8.3-A extension                                                                                | 1           |
 | [`__ARM_FEATURE_COPROC`](#coprocessor-intrinsics)                                                                                                       | Coprocessor Intrinsics                                                                             | 1           |
 | [`__ARM_FEATURE_CRC32`](#crc32-extension)                                                                                                               | CRC32 extension                                                                                    | 1           |
@@ -4979,6 +4985,58 @@ The fourth argument can contain the following values:
 | -------------------- | --------- | --------------------------------------------------------------------------------- |
 | KEEP                 | 0         | Signals to retain the updated location in the local cache of the updating PE.     |
 | STRM                 | 1         | Signals to not retain the updated location in the local cache of the updating PE. |
+
+## Atomic store with CMH intrinsics
+
+These intrinsics provide an atomic store, which will
+make use of the `STCPH` or `SHUH` hint instructions immediately followed by the
+associated store instruction. These intrinsics are type generic and 
+support scalar types from 8-64 bits and are available when
+`__ARM_FEATURE_CMH` is defined.
+
+To access these intrinsics, `<arm_acle.h>` should be included.
+
+``` c
+  void __arm_atomic_store_with_stcph(type *ptr, type data, int memory_order);
+  void __arm_atomic_store_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+```
+
+The first argument in these intrinsics is a pointer `ptr` which is the location to store to.
+The second argument `data` is the data which is to be stored.
+The third argument `mem` can be one of 3 memory ordering variables supported by atomic_store:
+__ATOMIC_RELAXED, __ATOMIC_SEQ_CST, and __ATOMIC_RELEASE.
+The fourth argument `priority_hint` can be either 0 or 1. If set to 1 then if the next instruction in program order generates
+an Explicit Memory Write Effect, then there is a performance benefit if that Explicit Memory Write Effect
+is sequenced before Memory Effects from other threads of execution in the coherence order to the same
+location.
+
+## Atomic fetch with CMH intrinsics
+
+These intrinsics provide some atomic fetch operations, which will
+make use of the `SHUH` hint instruction immediately followed by the
+associated fetch instructions. These intrinsics are type generic and 
+support scalar types from 8-64 bits and are available when
+`__ARM_FEATURE_CMH` is defined.
+
+To access these intrinsics, `<arm_acle.h>` should be included.
+
+``` c
+  type __arm_atomic_fetch_add_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+  type __arm_atomic_fetch_sub_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+  type __arm_atomic_fetch_and_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+  type __arm_atomic_fetch_xor_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+  type __arm_atomic_fetch_or_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+  type __arm_atomic_fetch_nand_with_shuh(type *ptr, type data, int memory_order, int priority_hint);
+```
+
+The first argument in these intrinsic is a pointer `ptr` which is the location to store to.
+The second argument `data` is the data which is to be stored.
+The third argument `mem` can be one of 6 memory ordering variables supported by atomic_fetch:
+__ATOMIC_RELAXED, __ATOMIC_SEQ_CST, __ATOMIC_ACQUIRE, __ATOMIC_CONSUME, __ATOMIC_ACQ_REL and __ATOMIC_RELEASE.
+The fourth argument `priority_hint` can be either 0 or 1. If set to 1 then if the next instruction in program order generates
+an Explicit Memory Write Effect, then there is a performance benefit if that Explicit Memory Write Effect
+is sequenced before Memory Effects from other threads of execution in the coherence order to the same
+location.
 
 # Custom Datapath Extension
 

--- a/main/acle.md
+++ b/main/acle.md
@@ -509,7 +509,7 @@ Armv8.4-A [[ARMARMv84]](#ARMARMv84). Support is added for the Dot Product intrin
 * Added [**Alpha**](#current-status-and-anticipated-changes)
   support for SVE2.3 (FEAT_SVE2p3) and SME2.3 shift right narrow intrinsics.
 * Bumped armv9.6 intrinsics implementation to [**Beta**](#current-status-and-anticipated-changes)
-* Added support for producer-consumer data placement hints. [**Alpha** state]
+* Added support for producer-consumer data placement hints.
 
 ### References
 
@@ -1871,7 +1871,7 @@ execution state. Intrinsics for the use of these instructions are specified in
 data placement hints (FEAT_PCDPHINT) instructions and their associated
 intrinsics are available on the target.
 
-### Contention Management hints [**Alpha** state]
+### Contention Management hints
 
 `__ARM_FEATURE_CMH` is defined to `1` if the Contention Management hints
 (FEAT_CMH) instructions and their associated intrinsics are available on the target.
@@ -5068,7 +5068,7 @@ target. The following hint values are defined:
 | HINT_SHUH        | 3         | `__ARM_FEATURE_CMH`        | Informs that the next instruction generates an effect in a location that one or more other threads of execution are likely to subsequently update. |
 | HINT_SHUH_PH     | 4         | `__ARM_FEATURE_CMH`        | PH adds the effects of STCPH to SHUH. |
 
-## Atomic fetch with hints intrinsics [**Alpha** state]
+## Atomic fetch with hints intrinsics
 
 These intrinsics provide some atomic fetch operations, which will
 make use of hint instructions immediately followed by the

--- a/main/acle.md
+++ b/main/acle.md
@@ -5000,7 +5000,7 @@ target. The following hint values are defined:
 These intrinsics provide some atomic fetch operations, which will
 make use of hint instructions immediately followed by the
 associated fetch instructions. These intrinsics are type generic and 
-supports scalar integral and floating-point types of 8, 16, 32, and 64 bits.
+support scalar integral types of 8, 16, 32, and 64 bits.
 
 To access these intrinsics, `<arm_acle.h>` should be included.
 
@@ -5012,8 +5012,8 @@ To access these intrinsics, `<arm_acle.h>` should be included.
   type __arm_atomic_fetch_or_with_hint(type *ptr, type data, int memory_order, int hint);
 ```
 
-The first argument in these intrinsic is a pointer `ptr` which is the location to store to.
-The second argument `data` is the data which is to be stored.
+The first argument in these intrinsic is a pointer `ptr` which is the location for read-modify-write.
+The second argument `data` is the data which is to be used in the RMW operation.
 The third argument `mem` can be one of 6 memory ordering variables supported by atomic_fetch:
 __ATOMIC_RELAXED, __ATOMIC_SEQ_CST, __ATOMIC_ACQUIRE, __ATOMIC_CONSUME, __ATOMIC_ACQ_REL and __ATOMIC_RELEASE.
 


### PR DESCRIPTION
---
Hi all,

This is a PR to propose the addition of new intrinsics required as part of FEAT_CMH.

Quality Level: ALP

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [x] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
