### PR TITLE
[FMV] Add support-level table and remove __ARM_ACLE_VERSION

### DIFF
--- a/main/acle.md
+++ b/main/acle.md
@@ -1499,32 +1499,8 @@ enclose them in parentheses if they are not simple constants.
 
 ## Testing for Arm C Language Extensions
 
-`__ARM_ACLE` is defined as the version of this specification that is
-implemented, formatted as `{YEAR}{QUARTER}{PATCH}`. The `YEAR` segment is
-composed of 4 digits, the `QUARTER` segment is composed of 1 digit, and
-the `PATCH` segment is also composed of 1 digit.
-
-For example:
-
- - An implementation based on the version 2023 Q2 of the ACLE with no
-   further patch releases will define `__ARM_ACLE` as `202320`.
- - An implementation based on a hypothetical version 2024 Q3 of the ACLE
-   with two patch releases will define `__ARM_ACLE` as `202432`.
-
-NOTE: Previously, the macro followed the previous versioning scheme and
-was defined as `100 * major_version + minor_version`, which was the
-version of this specification implemented. For instance, an implementation
-implementing version 2.1 of the ACLE specification defined `__ARM_ACLE`
-as `201`.
-
-`__ARM_ACLE_VERSION(year, quarter, patch)` is defined to express a given
-ACLE version. Returns with the version number in the same format as the
-`__ARM_ACLE` does. Checking the minimum required ACLE version could be
-written as:
-
-``` c
-#if __ARM_ACLE >= __ARM_ACLE_VERSION(2024, 1, 0)
-```
+An implementation that supports the Arm C Language Extensions defines `__ARM_ACLE`.
+For compatibility with existing code, the recommended value of this macro is `202420`.
 
 ## Endianness
 
@@ -2998,14 +2974,8 @@ following:
 versioning mechanism described in this section is supported by the
 compiler and it is enabled.
 
-`__FUNCTION_MULTI_VERSIONING_SUPPORT_LEVEL` is defined to the currently supported
-version of the ACLE. The value and the format are the same as the `__ARM_ACLE`.
-
-For example, it can be implemented as:
-
-``` c
-#define __FUNCTION_MULTI_VERSIONING_SUPPORT_LEVEL __ARM_ACLE_VERSION(2024, 3, 0)
-```
+`__FUNCTION_MULTI_VERSIONING_SUPPORT_LEVEL` is defined as a value corresponding to the
+support level listed in [Function Multi Versioning feature availability](#function-multi-versioning-feature-availability).
 
 ### Target version strings
 
@@ -3129,6 +3099,71 @@ The following table lists the architectures feature mapping for AArch64.
    | `FEAT_CSSC`              | cssc          | ```ID_AA64ISAR2_EL1.CSSC >= 0b0001```     |
 
 The tables are sorted by priority, starting from features of lowest priority ending with features of highest priority.
+
+### Function Multi Versioning feature availability
+
+The following table lists the Function Multi Versioning support level at
+which each target version name became available.
+
+A Function Multi Versioning target version name is supported when
+`__HAVE_FUNCTION_MULTI_VERSIONING` is defined to `1` and
+`__FUNCTION_MULTI_VERSIONING_SUPPORT_LEVEL` is greater than or equal to
+the support level listed for that name. Support for a given support level
+includes all target version names introduced at earlier support levels,
+unless otherwise specified.
+
+
+   | **Name**      | **Minimum support level** |
+   | ------------- | ------------------------- |
+   | default       | **202210**                |
+   | sha1          | 202210                    |
+   | aes           | 202210                    |
+   | vmull         | 202210                    |
+   | rng           | 202210                    |
+   | flagm         | 202210                    |
+   | flagm2        | 202210                    |
+   | lse           | 202210                    |
+   | dotprod       | 202210                    |
+   | rdm           | 202210                    |
+   | fp16          | 202210                    |
+   | dit           | 202210                    |
+   | dpb           | 202210                    |
+   | dpb2          | 202210                    |
+   | jscvt         | 202210                    |
+   | fcma          | 202210                    |
+   | frintts       | 202210                    |
+   | sve           | 202210                    |
+   | sve2          | 202210                    |
+   | sme           | 202210                    |
+   | sb            | 202210                    |
+   | ssbs          | 202210                    |
+   | bti           | 202210                    |
+   | crc           | **202240**                |
+   | sha2          | 202240                    |
+   | fp            | 202240                    |
+   | simd          | 202240                    |
+   | sm4           | 202240                    |
+   | sha3          | 202240                    |
+   | fp16fml       | 202240                    |
+   | rcpc          | 202240                    |
+   | rcpc2         | 202240                    |
+   | i8mm          | 202240                    |
+   | bf16          | 202240                    |
+   | f32mm         | 202240                    |
+   | f64mm         | 202240                    |
+   | sve2-aes      | 202240                    |
+   | sve2-bitperm  | 202240                    |
+   | sve2-sha3     | 202240                    |
+   | sve2-sm4      | 202240                    |
+   | memtag        | 202240                    |
+   | wfxt          | 202240                    |
+   | sme2          | 202240                    |
+   | rcpc3         | **202320**                |
+   | sme-f64f64    | 202320                    |
+   | sme-i16i64    | 202320                    |
+   | rdma          | **202410**                |
+   | mops          | 202410                    |
+   | cssc          | **202520**                |
 
 ### Dependencies
 


### PR DESCRIPTION
Remove __ARM_ACLE_VERSION, change __ARM_ACLE to represent when the header is available, and update __FUNCTION_MULTI_VERSIONING_SUPPORT_LEVEL so that it refers to a new Function Multi Versioning feature availability table.

For backwards compatibility with previous features, the table lists the support level at which each current FMV target version name became available. It also defines how future FMV feature sets allocate new support levels.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
