### PR TITLE
Rename vmmlaq_f16_f16 to vmmlaq_f16

### DIFF
--- a/neon_intrinsics/advsimd.md
+++ b/neon_intrinsics/advsimd.md
@@ -170,10 +170,11 @@ for more information about Arm’s trademarks.
   floating point conversion intrinsics from "Half Precision to 32-bit"
   and "Half Precision to 64-bit".
 
-### Changes for next release
+### Changes since 2026Q1
 
 * Added support for FEAT_F16F32DOT
 * Added support for FEAT_F16F32MM and FEAT_F16MM
+* Renamed vmmlaq_f16_f16 to vmmlaq_f16
 
 <!---
 **** Do not remove! ****
@@ -6251,6 +6252,6 @@ The intrinsics in this section are guarded by the macro ``__ARM_NEON``.
 
 #### Matrix multiply
 
-| Intrinsic                                                                                                                                                                                                                                                                                  | Argument preparation                         | AArch64 Instruction         | Result            | Supported architectures   |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|-----------------------------|-------------------|---------------------------|
-| <code>float16x8_t <a href="https://developer.arm.com/architectures/instruction-sets/intrinsics/vmmlaq_f16_f16" target="_blank">vmmlaq_f16_f16</a>(<br>&nbsp;&nbsp;&nbsp;&nbsp; float16x8_t r,<br>&nbsp;&nbsp;&nbsp;&nbsp; float16x8_t a,<br>&nbsp;&nbsp;&nbsp;&nbsp; float16x8_t b)</code> | `r -> Vd.8H`<br>`a -> Vn.8H`<br>`b -> Vm.8H` | `FMMLA Vd.8H, Vn.8H, Vm.8H` | `Vd.8H -> result` | `A64`                     |
+| Intrinsic                                                                                                                                                                                                                                                                          | Argument preparation                         | AArch64 Instruction         | Result            | Supported architectures   |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|-----------------------------|-------------------|---------------------------|
+| <code>float16x8_t <a href="https://developer.arm.com/architectures/instruction-sets/intrinsics/vmmlaq_f16" target="_blank">vmmlaq_f16</a>(<br>&nbsp;&nbsp;&nbsp;&nbsp; float16x8_t r,<br>&nbsp;&nbsp;&nbsp;&nbsp; float16x8_t a,<br>&nbsp;&nbsp;&nbsp;&nbsp; float16x8_t b)</code> | `r -> Vd.8H`<br>`a -> Vn.8H`<br>`b -> Vm.8H` | `FMMLA Vd.8H, Vn.8H, Vm.8H` | `Vd.8H -> result` | `A64`                     |

--- a/neon_intrinsics/advsimd.template.md
+++ b/neon_intrinsics/advsimd.template.md
@@ -170,10 +170,11 @@ for more information about Arm’s trademarks.
   floating point conversion intrinsics from "Half Precision to 32-bit"
   and "Half Precision to 64-bit".
 
-### Changes for next release
+### Changes since 2026Q1
 
 * Added support for FEAT_F16F32DOT
 * Added support for FEAT_F16F32MM and FEAT_F16MM
+* Renamed vmmlaq_f16_f16 to vmmlaq_f16
 
 <!---
 **** Do not remove! ****

--- a/tools/intrinsic_db/advsimd.csv
+++ b/tools/intrinsic_db/advsimd.csv
@@ -4848,4 +4848,4 @@ float32x4_t vdotq_lane_f32_f16(float32x4_t r, float16x8_t a, float16x4_t b, __bu
 float32x4_t vmmlaq_f32_f16(float32x4_t r, float16x8_t a, float16x8_t b)	r -> Vd.4S;a -> Vn.8H;b -> Vm.8H	FMMLA Vd.4S, Vn.8H, Vm.8H	Vd.4S -> result	A64
 
 <SECTION>	Non-widening half-precision matrix multiply instruction. Requires the +f16mm architecture extension.
-float16x8_t vmmlaq_f16_f16(float16x8_t r, float16x8_t a, float16x8_t b)	r -> Vd.8H;a -> Vn.8H;b -> Vm.8H	FMMLA Vd.8H, Vn.8H, Vm.8H	Vd.8H -> result	A64
+float16x8_t vmmlaq_f16(float16x8_t r, float16x8_t a, float16x8_t b)	r -> Vd.8H;a -> Vn.8H;b -> Vm.8H	FMMLA Vd.8H, Vn.8H, Vm.8H	Vd.8H -> result	A64

--- a/tools/intrinsic_db/advsimd_classification.csv
+++ b/tools/intrinsic_db/advsimd_classification.csv
@@ -4726,4 +4726,4 @@ vdotq_laneq_f32_f16	Vector arithmetic|Dot product
 vdot_laneq_f32_f16	Vector arithmetic|Dot product
 vdotq_lane_f32_f16	Vector arithmetic|Dot product
 vmmlaq_f32_f16	Vector arithmetic|Matrix multiply
-vmmlaq_f16_f16	Vector arithmetic|Matrix multiply
+vmmlaq_f16	Vector arithmetic|Matrix multiply


### PR DESCRIPTION
After some internal debate we consider this matches convention better.

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [ ] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in the section **Changes for next
      release** of the section **Change Control**/**Document history**
      of the document. Create **Changes for next release** if it does
      not exist. Notice that changes that are not modifying the
      content and rendering of the specifications (both HTML and PDF)
      do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] The variable `draftversion` is set to `true` in the YAML header
      of the sources of the specifications I have modified.
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
