### PR TITLE
Standardise on straight quotes in CC-BY-SA-4.0 notices. [NFC]

### DIFF
--- a/cmse/TRADEMARK_NOTICE.md
+++ b/cmse/TRADEMARK_NOTICE.md
@@ -6,7 +6,7 @@
 
 The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/cmse/cmse.md
+++ b/cmse/cmse.md
@@ -104,7 +104,7 @@ retain the copyright.
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/main/TRADEMARK_NOTICE.md
+++ b/main/TRADEMARK_NOTICE.md
@@ -6,7 +6,7 @@
 
 The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/main/acle.md
+++ b/main/acle.md
@@ -102,7 +102,7 @@ retain the copyright.
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/morello/TRADEMARK_NOTICE.md
+++ b/morello/TRADEMARK_NOTICE.md
@@ -6,7 +6,7 @@
 
 The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/mve_intrinsics/TRADEMARK_NOTICE.md
+++ b/mve_intrinsics/TRADEMARK_NOTICE.md
@@ -6,7 +6,7 @@
 
 The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/neon_intrinsics/TRADEMARK_NOTICE.md
+++ b/neon_intrinsics/TRADEMARK_NOTICE.md
@@ -6,7 +6,7 @@
 
 The text of and illustrations in this folder are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/neon_intrinsics/advsimd.md
+++ b/neon_intrinsics/advsimd.md
@@ -96,7 +96,7 @@ retain the copyright.
 
 The text of and illustrations in this document are licensed by Arm under
 a Creative Commons Attribution–Share Alike 4.0 International license
-("CC-BY-SA-4.0”), with an additional clause on patents. The Arm
+("CC-BY-SA-4.0"), with an additional clause on patents. The Arm
 trademarks featured here are registered trademarks or trademarks of Arm
 Limited (or its subsidiaries) in the US and/or elsewhere. All rights
 reserved. Please visit <https://www.arm.com/company/policies/trademarks>

--- a/neon_intrinsics/advsimd.template.md
+++ b/neon_intrinsics/advsimd.template.md
@@ -96,7 +96,7 @@ retain the copyright.
 
 The text of and illustrations in this document are licensed by Arm under
 a Creative Commons Attribution–Share Alike 4.0 International license
-("CC-BY-SA-4.0”), with an additional clause on patents. The Arm
+("CC-BY-SA-4.0"), with an additional clause on patents. The Arm
 trademarks featured here are registered trademarks or trademarks of Arm
 Limited (or its subsidiaries) in the US and/or elsewhere. All rights
 reserved. Please visit <https://www.arm.com/company/policies/trademarks>


### PR DESCRIPTION
The ABI and ACLE mix two different comment characters in several documents "CC-BY-SA-4.0”. Standardise on straight quotes "CC-BY-SA-4.0".

---
name: Pull request
about: Technical issues, document format problems, bugs in scripts or feature proposal.

---

<!-- SPDX-FileCopyrightText: Copyright 2021-2022, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

**Thank you for submitting a pull request!**

If this PR is about a bugfix:

Please use the bugfix label and make sure to go through the checklist below.

If this PR is about a proposal:

We are looking forward to evaluate your proposal, and if possible to
make it part of the Arm C Language Extension (ACLE) specifications.

We would like to encourage you reading through the [contribution
guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md), in particular the section on [submitting
a proposal](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#proposals-for-new-content).

Please use the proposal label.

As for any pull request, please make sure to go through the below
checklist.

Checklist: (mark with ``X`` those which apply)

* [ ] If an issue reporting the bug exists, I have mentioned it in the
      PR (do not bother creating the issue if all you want to do is
      fixing the bug yourself).
* [ ] I have added/updated the `SPDX-FileCopyrightText` lines on top
      of any file I have edited. Format is `SPDX-FileCopyrightText:
      Copyright {year} {entity or name} <{contact informations}>`
      (Please update existing copyright lines if applicable. You can
      specify year ranges with hyphen , as in `2017-2019`, and use
      commas to separate gaps, as in `2018-2020, 2022`).
* [ ] I have updated the `Copyright` section of the sources of the
      specification I have edited (this will show up in the text
      rendered in the PDF and other output format supported). The
      format is the same described in the previous item.
* [X] I have run the CI scripts (if applicable, as they might be
      tricky to set up on non-*nix machines). The sequence can be
      found in the [contribution
      guidelines](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration). Don't
      worry if you cannot run these scripts on your machine, your
      patch will be automatically checked in the Actions of the pull
      request.
* [ ] I have added an item that describes the changes I have
      introduced in this PR in section **Changelog for year 20xx** (this year)
      of section **Preface**/**About this document**.
      Create **Changelog for year 20xx** if it does not exist. Notice that
      changes that are not modifying the content and rendering of the
      specifications (both HTML and PDF) do not need to be listed.
* [ ] When modifying content and/or its rendering, I have checked the
      correctness of the result in the PDF output (please refer to the
      instructions on [how to build the PDFs
      locally](https://github.com/ARM-software/acle/blob/main/CONTRIBUTING.md#continuous-integration)).
* [ ] Please *DO NOT* add my GitHub profile to the list of contributors
      in the [README](https://github.com/ARM-software/acle/blob/main/README.md#contributors-) page of the project.
