### PR TITLE
CI: add link check exceptions for frequent 429s

### DIFF
--- a/.github/scripts/check_links.py
+++ b/.github/scripts/check_links.py
@@ -112,8 +112,20 @@ def main() -> int:
 			and status_code == "403"
 		)
 
+		is_ignored_gcc_or_sourceware_429 = (
+			parsed_url.hostname in {"gcc.gnu.org", "sourceware.org"}
+			and status == "dead"
+			and status_code == "429"
+		)
+
 		if is_ignored_developer_arm_403:
 			print(f"IGNORED (403 from developer.arm.com): {url}")
+			continue
+
+		if is_ignored_gcc_or_sourceware_429:
+			print(
+				f"IGNORED (429 from {parsed_url.hostname}): {url}",
+			)
 			continue
 
 		failure = testcase.find("failure")


### PR DESCRIPTION
Currently, the markdown-link-check workflow frequently fails not because some link is actually broken, but because we often get 429s (too many requests) on two domains (gnu and sourceware). In this patch, we purposely ignore those 429s and let the workflow pass in this case.