### PR TITLE
CI: update actions/upload-pages-artifact to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Build GitHub Pages site
       run: ./tools/build-github-pages.sh build --finalversion
     - name: Upload GitHub Pages artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: _site
 


### PR DESCRIPTION
The deprecation warnings related to using Node 20 still appear in
workflow build-pages-artifact because actions/upload-pages-artifact@v4
in turn still uses a version of actions/upload-artifact that uses Node
20. Fix this by updating actions/upload-pages-artifact.